### PR TITLE
Update dependencies according to semver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
   ],
   "require": {
     "php": ">=5.5",
-    "guzzlehttp/guzzle": "6.3.3",
-    "psr/log": "1.1.0",
+    "guzzlehttp/guzzle": "^6.3",
+    "psr/log": "^1.1",
     "ext-json": "*",
-    "phlak/semver": "1.0.0"
+    "phlak/semver": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
The exactly defined version numbers don't allow to upgrade to newer versions of the dependencies. I'd suggest to require versions which according to semver shouldn't break.
(Actual example: current version of psr/log is 1.1.2, which I'd like to install.)