### PR TITLE
Update guzzle dependency. Closes #9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^6.3 || ^7.0",
     "psr/log": "^1.1",
     "ext-json": "*",
     "monolog/monolog": "^1.6|^2.0",


### PR DESCRIPTION
It should be backwards compatible. Hope it can be released in `5.x`