### PR TITLE
Fixed name for to set connect timeout. From connect-timeout ti connect_timeout.

### DIFF
--- a/src/ConfigFetcher.php
+++ b/src/ConfigFetcher.php
@@ -78,7 +78,7 @@ final class ConfigFetcher
             : [];
 
         if (!isset($additionalOptions['connect-timeout'])) {
-            $additionalOptions['connect-timeout'] = 10;
+            $additionalOptions['connect_timeout'] = 10;
         }
 
         if (!isset($additionalOptions['timeout'])) {


### PR DESCRIPTION
### Describe the purpose of your pull request

Guzzle parameter to set connect timeout is `connect_timeout` and not `connect-timeout`
See https://github.com/guzzle/guzzle/blob/de6f1e58e735754b888649495ed4cb9ae3b19589/src/RequestOptions.php#L75

Did not updated any test since there were none for this part