### PR TITLE
Added return types for InternalLogger. Closes #20

### DIFF
--- a/src/Log/InternalLogger.php
+++ b/src/Log/InternalLogger.php
@@ -31,68 +31,68 @@ class InternalLogger implements LoggerInterface
         $this->exceptionsToIgnore = $exceptionsToIgnore;
     }
 
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::EMERGENCY, $context)) {
             $this->logger->emergency($message, $context);
         }
     }
 
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::ALERT, $context)) {
             $this->logger->alert($message, $context);
         }
     }
 
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::CRITICAL, $context)) {
             $this->logger->critical($message, $context);
         }
     }
 
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::ERROR, $context)) {
             $this->logger->error($message, $context);
         }
     }
 
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::WARNING, $context)) {
             $this->logger->warning($message, $context);
         }
     }
 
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::NOTICE, $context)) {
             $this->logger->notice($message, $context);
         }
     }
 
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::INFO, $context)) {
             $this->logger->info($message, $context);
         }
     }
 
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::DEBUG, $context)) {
             $this->logger->debug($message, $context);
         }
     }
 
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         // Do nothing, only the leveled methods should be used.
     }
 
-    private function shouldLog($currentLevel, array $context)
+    private function shouldLog($currentLevel, array $context): bool
     {
         if ($currentLevel >= $this->globalLevel && !$this->hasAnythingToIgnore($context)) {
             return true;
@@ -101,7 +101,7 @@ class InternalLogger implements LoggerInterface
         return false;
     }
 
-    private function hasAnythingToIgnore(array $context)
+    private function hasAnythingToIgnore(array $context): bool
     {
         if (empty($this->exceptionsToIgnore) ||
             empty($context) ||


### PR DESCRIPTION
### Describe the purpose of your pull request

Return types are missing in InternalLogger and it was producing deprecation issues.

### Related issues (only if applicable)

[Deprecation regarding LoggerInterface implementation inside InternalLogger (needs return types)](https://github.com/configcat/php-sdk/issues/20)
