### PR TITLE
Bump PHP prior to 8.1

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.1' ]
     steps:
     - uses: actions/checkout@v3
 
@@ -53,7 +53,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.1'
         extensions: xdebug
 
     - name: Validate composer.json and composer.lock

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,4 @@
     "psr/simple-cache": "When using any PSR16 SimpleCache implementation, a pre-built cache adapter \\ConfigCat\\Psr16Cache can be used as the main cache of the library.",
     "laravel/framework": "When using laravel, a pre-built cache adapter \\ConfigCat\\LaravelCache can be used as the main cache of the library."
   }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,19 +13,19 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
-    "guzzlehttp/guzzle": "^6.3|^7.0",
-    "psr/log": "^1.1",
+    "php": ">=8.1",
+    "guzzlehttp/guzzle": "^6.5|^7.4",
+    "psr/log": "^2.0 || ^3.0",
     "ext-json": "*",
-    "monolog/monolog": "^1.6|^2.0",
+    "monolog/monolog": "^3.0",
     "z4kn4fein/php-semver": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.0|^8",
-    "illuminate/cache": "^5.0",
-    "psr/simple-cache": "^1.0",
-    "psr/cache": "^1.0",
-    "squizlabs/php_codesniffer": "3.5.1"
+    "illuminate/cache": "^9.41",
+    "psr/simple-cache": "^3.0",
+    "psr/cache": "^3.0",
+    "squizlabs/php_codesniffer": "^3.7"
   },
   "autoload": {
     "psr-4": {
@@ -41,5 +41,6 @@
     "psr/cache": "When using any PSR6 Cache implementation, a pre-built cache adapter \\ConfigCat\\Psr6Cache can be used as the main cache of the library.",
     "psr/simple-cache": "When using any PSR16 SimpleCache implementation, a pre-built cache adapter \\ConfigCat\\Psr16Cache can be used as the main cache of the library.",
     "laravel/framework": "When using laravel, a pre-built cache adapter \\ConfigCat\\LaravelCache can be used as the main cache of the library."
+  }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
   ],
   "require": {
     "php": ">=8.1",
-    "guzzlehttp/guzzle": "^6.5|^7.4",
+    "guzzlehttp/guzzle": "^6.5 || ^7.4",
     "psr/log": "^2.0 || ^3.0",
     "ext-json": "*",
-    "monolog/monolog": "^3.0",
+    "monolog/monolog": "^2.0 || ^3.0",
     "z4kn4fein/php-semver": "^2.0"
   },
   "require-dev": {

--- a/samples/consolesample/composer.json
+++ b/samples/consolesample/composer.json
@@ -1,6 +1,10 @@
 {
+    "name": "configcat/vanilla-php-sample",
+    "description": "Sample: ConfigCat integration into vanilla PHP.",
     "require": {
-        "configcat/configcat-client": "^6",
-        "monolog/monolog": "^1.0"
-    }
+        "php": "^8.1",
+        "configcat/configcat-client": "^7"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/samples/consolesample/consolesample.php
+++ b/samples/consolesample/consolesample.php
@@ -1,16 +1,28 @@
 <?php
 
+use ConfigCat\ClientOptions;
+use ConfigCat\ConfigCatClient;
+use ConfigCat\Log\LogLevel;
+use ConfigCat\User;
+use Monolog\Logger;
+
 require __DIR__ . '/vendor/autoload.php';
 
-$client = new \ConfigCat\ConfigCatClient("PKDVCLf-Hq-h-kCzMp-L7Q/HhOWfwVtZ0mb30i9wi17GQ", [
-    \ConfigCat\ClientOptions::LOGGER => new \Monolog\Logger("consolesample"),
-    // Info level logging helps to inspect the feature flag evaluation process.
-    // Use the default Warning level to avoid too detailed logging in your application.
-    \ConfigCat\ClientOptions::LOG_LEVEL => \ConfigCat\Log\LogLevel::INFO,
-]);
+$client = new ConfigCatClient(
+    'PKDVCLf-Hq-h-kCzMp-L7Q/HhOWfwVtZ0mb30i9wi17GQ',
+    [
+        ClientOptions::LOGGER => new Logger('consolesample'),
+        // Info level logging helps to inspect the feature flag evaluation process.
+        // Use the default Warning level to avoid too detailed logging in your application.
+        ClientOptions::LOG_LEVEL => LogLevel::INFO,
+    ]
+);
 
-$user = new \ConfigCat\User("Some UserID",
-    "configcat@example.com", "Awesomnia", [ "version" => "1.0.0" ]
+$user = new User(
+    'Some UserID',
+    'configcat@example.com',
+    'Awesomnia',
+    [ 'version' => '1.0.0' ]
 );
 
 $value = $client->getValue('isPOCFeatureEnabled', false, $user);

--- a/samples/laravel/composer.json
+++ b/samples/laravel/composer.json
@@ -1,17 +1,17 @@
 {
-    "name": "laravel/laravel",
+    "name": "configcat/laravel-sample",
     "type": "project",
-    "description": "The Laravel Framework.",
+    "description": "Sample: ConfigCat integration into Laravel Framework.",
     "keywords": [
         "framework",
         "laravel"
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2.5",
-        "configcat/configcat-client": "^6",
+        "php": "^8.1",
+        "configcat/configcat-client": "^7",
         "fideloper/proxy": "^4.0",
-        "laravel/framework": "^7.0",
+        "laravel/framework": "^8.83",
         "laravel/tinker": "^2.0"
     },
     "require-dev": {

--- a/src/Attributes/Config.php
+++ b/src/Attributes/Config.php
@@ -4,10 +4,9 @@ namespace ConfigCat\Attributes;
 
 /**
  * Represents the root JSON keys of a ConfigCat configuration file.
- * @package ConfigCat
  */
 class Config
 {
-    const PREFERENCES = "p";
-    const ENTRIES = "f";
+    final public const PREFERENCES = 'p';
+    final public const ENTRIES = 'f';
 }

--- a/src/Attributes/PercentageAttributes.php
+++ b/src/Attributes/PercentageAttributes.php
@@ -4,11 +4,10 @@ namespace ConfigCat\Attributes;
 
 /**
  * Represents the JSON keys of a ConfigCat percentage rule.
- * @package ConfigCat
  */
 class PercentageAttributes
 {
-    const VALUE = "v";
-    const PERCENTAGE = "p";
-    const VARIATION_ID = "i";
+    final public const VALUE = 'v';
+    final public const PERCENTAGE = 'p';
+    final public const VARIATION_ID = 'i';
 }

--- a/src/Attributes/Preferences.php
+++ b/src/Attributes/Preferences.php
@@ -4,10 +4,9 @@ namespace ConfigCat\Attributes;
 
 /**
  * Represents the JSON keys of the Preferences section in the ConfigCat configuration file.
- * @package ConfigCat
  */
 class Preferences
 {
-    const BASE_URL = "u";
-    const REDIRECT = "r";
+    final public const BASE_URL = 'u';
+    final public const REDIRECT = 'r';
 }

--- a/src/Attributes/RolloutAttributes.php
+++ b/src/Attributes/RolloutAttributes.php
@@ -4,13 +4,12 @@ namespace ConfigCat\Attributes;
 
 /**
  * Represents the JSON keys of a ConfigCat roll-out rule.
- * @package ConfigCat
  */
 class RolloutAttributes
 {
-    const VALUE = "v";
-    const COMPARISON_ATTRIBUTE = "a";
-    const COMPARATOR = "t";
-    const COMPARISON_VALUE = "c";
-    const VARIATION_ID = "i";
+    final public const VALUE = 'v';
+    final public const COMPARISON_ATTRIBUTE = 'a';
+    final public const COMPARATOR = 't';
+    final public const COMPARISON_VALUE = 'c';
+    final public const VARIATION_ID = 'i';
 }

--- a/src/Attributes/SettingAttributes.php
+++ b/src/Attributes/SettingAttributes.php
@@ -4,13 +4,12 @@ namespace ConfigCat\Attributes;
 
 /**
  * Represents the JSON keys of a ConfigCat setting.
- * @package ConfigCat
  */
 class SettingAttributes
 {
-    const VALUE = "v";
-    const TYPE = "t";
-    const ROLLOUT_PERCENTAGE_ITEMS = "p";
-    const ROLLOUT_RULES = "r";
-    const VARIATION_ID = "i";
+    final public const VALUE = 'v';
+    final public const TYPE = 't';
+    final public const ROLLOUT_PERCENTAGE_ITEMS = 'p';
+    final public const ROLLOUT_RULES = 'r';
+    final public const VARIATION_ID = 'i';
 }

--- a/src/Cache/ArrayCache.php
+++ b/src/Cache/ArrayCache.php
@@ -4,29 +4,28 @@ namespace ConfigCat\Cache;
 
 /**
  * Represents a simple cache which just uses a shared array to store the values.
- * @package ConfigCat
  */
 final class ArrayCache extends ConfigCache
 {
-    /** @var array */
-    private static $arrayCache = [];
+    private static array $arrayCache = [];
 
     /**
      * Reads the value identified by the given $key from the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @return string|null Cached value for the given key, or null if it's missing.
+     * @param string $key identifier for the cached value
+     *
+     * @return string|null cached value for the given key, or null if it's missing
      */
     protected function get(string $key): ?string
     {
-        return array_key_exists($key, self::$arrayCache) ? self::$arrayCache[$key] : null;
+        return self::$arrayCache[$key] ?? null;
     }
 
     /**
      * Writes the value identified by the given $key into the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @param string $value The value to cache.
+     * @param string $key   identifier for the cached value
+     * @param string $value the value to cache
      */
     protected function set(string $key, string $value): void
     {

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -4,16 +4,15 @@ namespace ConfigCat\Cache;
 
 /**
  * Represents the cached configuration.
- * @package ConfigCat
  */
 class CacheItem
 {
-    /** @var int The time the cached entry refreshed. */
-    public $lastRefreshed = 0;
-    /** @var string The ETag. */
-    public $etag;
-    /** @var array The cached JSON configuration. */
-    public $config;
-    /** @var string The url pointing to the proper cdn server. */
-    public $url;
+    /** The time the cached entry refreshed. */
+    public int $lastRefreshed = 0;
+    /** The ETag. */
+    public ?string $etag = null;
+    /** The cached JSON configuration. */
+    public array $config;
+    /** The url pointing to the proper cdn server. */
+    public ?string $url = null;
 }

--- a/src/Cache/ConfigCache.php
+++ b/src/Cache/ConfigCache.php
@@ -9,42 +9,41 @@ use Psr\Log\LoggerInterface;
 
 /**
  * A cache API used to make custom cache implementations.
- * @package ConfigCat
  */
 abstract class ConfigCache implements LoggerAwareInterface
 {
-    /** @var LoggerInterface */
-    private $logger;
+    private ?LoggerInterface $logger = null;
 
     /**
      * Reads the value identified by the given $key from the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @return string|null Cached value for the given key, or null if it's missing.
+     * @param string $key identifier for the cached value
+     *
+     * @return string|null cached value for the given key, or null if it's missing
      */
     abstract protected function get(string $key): ?string;
 
     /**
      * Writes the value identified by the given $key into the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @param string $value The value to cache.
+     * @param string $key   identifier for the cached value
+     * @param string $value the value to cache
      */
     abstract protected function set(string $key, string $value): void;
 
     /**
      * Writes the value identified by the given $key into the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @param mixed $value The value to cache.
+     * @param string $key   identifier for the cached value
+     * @param mixed  $value the value to cache
      *
-     * @throws InvalidArgumentException
-     *   If the $key is not a legal value.
+     * @throws invalidArgumentException
+     *                                  If the $key is not a legal value
      */
     public function store(string $key, CacheItem $value): void
     {
         if (empty($key)) {
-            throw new InvalidArgumentException("key cannot be empty.");
+            throw new InvalidArgumentException('key cannot be empty.');
         }
 
         try {
@@ -57,16 +56,17 @@ abstract class ConfigCache implements LoggerAwareInterface
     /**
      * Reads the value identified by the given $key from the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @return CacheItem|null Cached value for the given key, or null if it's missing.
+     * @param string $key identifier for the cached value
      *
-     * @throws InvalidArgumentException
-     *   If the $key is not a legal value.
+     * @return CacheItem|null cached value for the given key, or null if it's missing
+     *
+     * @throws invalidArgumentException
+     *                                  If the $key is not a legal value
      */
     public function load(string $key): ?CacheItem
     {
         if (empty($key)) {
-            throw new InvalidArgumentException("key cannot be empty.");
+            throw new InvalidArgumentException('key cannot be empty.');
         }
 
         try {
@@ -74,7 +74,7 @@ abstract class ConfigCache implements LoggerAwareInterface
             if (!$cached) {
                 return null;
             }
-            
+
             $result = unserialize($cached);
             if ($result instanceof CacheItem) {
                 return $result;
@@ -88,8 +88,6 @@ abstract class ConfigCache implements LoggerAwareInterface
 
     /**
      * Sets a logger instance on the object.
-     *
-     * @param LoggerInterface $logger
      */
     public function setLogger(LoggerInterface $logger): void
     {

--- a/src/Cache/LaravelCache.php
+++ b/src/Cache/LaravelCache.php
@@ -7,21 +7,18 @@ use Psr\SimpleCache\InvalidArgumentException;
 
 class LaravelCache extends ConfigCache
 {
-    /** @var Repository */
-    private $cache;
-
-    public function __construct(Repository $cache)
+    public function __construct(private readonly Repository $cache)
     {
-        $this->cache = $cache;
     }
 
     /**
      * Reads the value identified by the given $key from the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @return string|null Cached value for the given key, or null if it's missing.
+     * @param string $key identifier for the cached value
      *
-     * @throws InvalidArgumentException If the $key is not a legal value.
+     * @return string|null cached value for the given key, or null if it's missing
+     *
+     * @throws InvalidArgumentException if the $key is not a legal value
      */
     protected function get(string $key): ?string
     {
@@ -31,8 +28,8 @@ class LaravelCache extends ConfigCache
     /**
      * Writes the value identified by the given $key into the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @param string $value The value to cache.
+     * @param string $key   identifier for the cached value
+     * @param string $value the value to cache
      */
     protected function set(string $key, string $value): void
     {

--- a/src/Cache/Psr16Cache.php
+++ b/src/Cache/Psr16Cache.php
@@ -7,21 +7,18 @@ use Psr\SimpleCache\InvalidArgumentException;
 
 class Psr16Cache extends ConfigCache
 {
-    /** @var CacheInterface */
-    private $cache;
-
-    public function __construct(CacheInterface $cache)
+    public function __construct(private readonly CacheInterface $cache)
     {
-        $this->cache = $cache;
     }
 
     /**
      * Reads the value identified by the given $key from the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @return string|null Cached value for the given key, or null if it's missing.
+     * @param string $key identifier for the cached value
      *
-     * @throws InvalidArgumentException If the $key is not a legal value.
+     * @return string|null cached value for the given key, or null if it's missing
+     *
+     * @throws InvalidArgumentException if the $key is not a legal value
      */
     protected function get(string $key): ?string
     {
@@ -31,10 +28,10 @@ class Psr16Cache extends ConfigCache
     /**
      * Writes the value identified by the given $key into the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @param string $value The value to cache.
+     * @param string $key   identifier for the cached value
+     * @param string $value the value to cache
      *
-     * @throws InvalidArgumentException If the $key is not a legal value.
+     * @throws InvalidArgumentException if the $key is not a legal value
      */
     protected function set(string $key, string $value): void
     {

--- a/src/Cache/Psr6Cache.php
+++ b/src/Cache/Psr6Cache.php
@@ -7,35 +7,33 @@ use Psr\Cache\InvalidArgumentException;
 
 class Psr6Cache extends ConfigCache
 {
-    /** @var CacheItemPoolInterface */
-    private $cachePool;
-
-    public function __construct(CacheItemPoolInterface $cachePool)
+    public function __construct(private readonly CacheItemPoolInterface $cachePool)
     {
-        $this->cachePool = $cachePool;
     }
 
     /**
      * Reads the value identified by the given $key from the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @return string|null Cached value for the given key, or null if it's missing.
+     * @param string $key identifier for the cached value
      *
-     * @throws InvalidArgumentException If the $key is not a legal value.
+     * @return string|null cached value for the given key, or null if it's missing
+     *
+     * @throws InvalidArgumentException if the $key is not a legal value
      */
     protected function get(string $key): ?string
     {
         $item = $this->cachePool->getItem($key);
+
         return $item->get();
     }
 
     /**
      * Writes the value identified by the given $key into the underlying cache.
      *
-     * @param string $key Identifier for the cached value.
-     * @param string $value The value to cache.
+     * @param string $key   identifier for the cached value
+     * @param string $value the value to cache
      *
-     * @throws InvalidArgumentException If the $key is not a legal value.
+     * @throws InvalidArgumentException if the $key is not a legal value
      */
     protected function set(string $key, string $value): void
     {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -4,68 +4,73 @@ namespace ConfigCat;
 
 /**
  * A client for handling configurations provided by ConfigCat.
- * @package ConfigCat
  */
 interface ClientInterface
 {
     /**
      * Gets a value of a feature flag or setting identified by the given key.
      *
-     * @param string $key The identifier of the configuration value.
-     * @param mixed $defaultValue In case of any failure, this value will be returned.
-     * @param User|null $user The user object to identify the caller.
-     * @return mixed The configuration value identified by the given key.
+     * @param string    $key          the identifier of the configuration value
+     * @param mixed     $defaultValue in case of any failure, this value will be returned
+     * @param User|null $user         the user object to identify the caller
+     *
+     * @return mixed the configuration value identified by the given key
      */
-    public function getValue(string $key, $defaultValue, User $user = null);
+    public function getValue(string $key, mixed $defaultValue, User $user = null): mixed;
 
     /**
      * Gets the value and evaluation details of a feature flag or setting identified by the given key.
      *
-     * @param string $key The identifier of the configuration value.
-     * @param mixed $defaultValue In case of any failure, this value will be returned.
-     * @param User|null $user The user object to identify the caller.
-     * @return mixed The configuration value identified by the given key.
+     * @param string    $key          the identifier of the configuration value
+     * @param mixed     $defaultValue in case of any failure, this value will be returned
+     * @param User|null $user         the user object to identify the caller
+     *
+     * @return EvaluationDetails the configuration value identified by the given key
      */
-    public function getValueDetails(string $key, $defaultValue, User $user = null): EvaluationDetails;
+    public function getValueDetails(string $key, mixed $defaultValue, User $user = null): EvaluationDetails;
 
     /**
      * Gets the Variation ID (analytics) of a feature flag or setting by the given key.
      *
-     * @param string $key The identifier of the configuration value.
-     * @param mixed $defaultVariationId In case of any failure, this value will be returned.
-     * @param User|null $user The user object to identify the caller.
-     * @return mixed The Variation ID identified by the given key.
+     * @param string    $key                the identifier of the configuration value
+     * @param mixed     $defaultVariationId in case of any failure, this value will be returned
+     * @param User|null $user               the user object to identify the caller
+     *
+     * @return mixed the Variation ID identified by the given key
      */
-    public function getVariationId(string $key, $defaultVariationId, User $user = null);
+    public function getVariationId(string $key, mixed $defaultVariationId, User $user = null): mixed;
 
     /**
      * Gets the Variation IDs (analytics) of all feature flags or settings.
      *
-     * @param User|null $user The user object to identify the caller.
-     * @return array of all Variation IDs.
+     * @param User|null $user the user object to identify the caller
+     *
+     * @return array of all Variation IDs
      */
     public function getAllVariationIds(User $user = null): array;
 
     /**
      * Gets the key of a setting and its value identified by the given Variation ID (analytics).
      *
-     * @param string $variationId The Variation ID.
-     * @return Pair|null of the key and value of a setting.
+     * @param string $variationId the Variation ID
+     *
+     * @return Pair|null of the key and value of a setting
      */
     public function getKeyAndValue(string $variationId): ?Pair;
 
     /**
      * Gets a collection of all setting keys.
      *
-     * @return array of keys.
+     * @return array of keys
      */
     public function getAllKeys(): array;
 
     /**
      * Gets the values of all feature flags or settings.
      *
-     * @param User|null $user The user object to identify the caller.
-     * @return array of values.
+     * @param User|null $user the user object to identify the caller
+     *
+     * @return array of values
      */
     public function getAllValues(User $user = null): array;
 
@@ -77,31 +82,31 @@ interface ClientInterface
     /**
      * Sets the default user.
      *
-     * @param User $user The default user.
+     * @param User $user the default user
      */
-    public function setDefaultUser(User $user);
+    public function setDefaultUser(User $user): void;
 
     /**
      * Sets the default user to null.
      */
-    public function clearDefaultUser();
+    public function clearDefaultUser(): void;
 
     /**
      * Gets the Hooks object for subscribing to SDK events.
      *
-     * @return Hooks for subscribing to SDK events.
+     * @return Hooks for subscribing to SDK events
      */
     public function hooks(): Hooks;
 
     /**
      * Configures the SDK to not initiate HTTP requests.
      */
-    public function setOffline();
+    public function setOffline(): void;
 
     /**
      * Configures the SDK to allow HTTP requests.
      */
-    public function setOnline();
+    public function setOnline(): void;
 
     /**
      * Indicates whether the SDK should be initialized in offline mode or not.

--- a/src/ClientOptions.php
+++ b/src/ClientOptions.php
@@ -10,64 +10,64 @@ final class ClientOptions
     /**
      * The base ConfigCat CDN url.
      */
-    const BASE_URL = "base-url";
+    public const BASE_URL = 'base-url';
 
     /**
      * A \Psr\Log\LoggerInterface implementation used for logging.
      */
-    const LOGGER = "logger";
+    public const LOGGER = 'logger';
 
     /**
      * Default: Warning. Sets the internal log level.
      */
-    const LOG_LEVEL = "log-level";
+    public const LOG_LEVEL = 'log-level';
 
     /**
      * A \ConfigCat\ConfigCache implementation used for caching.
      */
-    const CACHE = "cache";
+    public const CACHE = 'cache';
 
     /**
      * Array of exception classes that should be ignored from logs.
      */
-    const EXCEPTIONS_TO_IGNORE = "exceptions-to-ignore";
+    public const EXCEPTIONS_TO_IGNORE = 'exceptions-to-ignore';
 
     /**
      * Sets how frequent the cached configuration should be refreshed.
      */
-    const CACHE_REFRESH_INTERVAL = "cache-refresh-interval";
+    public const CACHE_REFRESH_INTERVAL = 'cache-refresh-interval';
 
     /**
      * Additional options for Guzzle http requests.
-     * https://docs.guzzlephp.org/en/stable/request-options.html
+     * https://docs.guzzlephp.org/en/stable/request-options.html.
      */
-    const REQUEST_OPTIONS = "request-options";
+    public const REQUEST_OPTIONS = 'request-options';
 
     /**
      * A custom callable Guzzle http handler.
      */
-    const CUSTOM_HANDLER = "custom-handler";
+    public const CUSTOM_HANDLER = 'custom-handler';
 
     /**
      * Default: Global. Set this parameter to be in sync with the Data Governance
      * preference on the Dashboard: https://app.configcat.com/organization/data-governance
-     * (Only Organization Admins can access)
+     * (Only Organization Admins can access).
      */
-    const DATA_GOVERNANCE = "data-governance";
+    public const DATA_GOVERNANCE = 'data-governance';
 
     /**
      * A \ConfigCat\Override\OverrideDataSource implementation used to override
      * feature flags & settings.
      */
-    const FLAG_OVERRIDES = "flag-overrides";
+    public const FLAG_OVERRIDES = 'flag-overrides';
 
     /**
      * A \ConfigCat\User as default user.
      */
-    const DEFAULT_USER = "default-user";
+    public const DEFAULT_USER = 'default-user';
 
     /**
      * Default: false. Indicates whether the SDK should be initialized in offline mode or not.
      */
-    const OFFLINE = "offline";
+    public const OFFLINE = 'offline';
 }

--- a/src/ConfigCatClientException.php
+++ b/src/ConfigCatClientException.php
@@ -4,5 +4,4 @@ namespace ConfigCat;
 
 class ConfigCatClientException extends \Exception
 {
-
 }

--- a/src/DataGovernance.php
+++ b/src/DataGovernance.php
@@ -4,14 +4,13 @@ namespace ConfigCat;
 
 /**
  * Describes the location of your feature flag and setting data within the ConfigCat CDN.
- * @package ConfigCat
  */
 final class DataGovernance
 {
     /** @var int Select this if your feature flags are published to all global CDN nodes. */
-    const GLOBAL_ = 0;
+    public const GLOBAL_ = 0;
     /** @var int Select this if your feature flags are published to CDN nodes only in the EU. */
-    const EU_ONLY = 1;
+    public const EU_ONLY = 1;
 
     public static function isValid($value): bool
     {
@@ -20,11 +19,11 @@ final class DataGovernance
 
     public static function isGlobal($value): bool
     {
-        return $value == self::GLOBAL_;
+        return self::GLOBAL_ == $value;
     }
 
     public static function isEuOnly($value): bool
     {
-        return $value == self::EU_ONLY;
+        return self::EU_ONLY == $value;
     }
 }

--- a/src/EvaluationDetails.php
+++ b/src/EvaluationDetails.php
@@ -4,56 +4,28 @@ namespace ConfigCat;
 
 class EvaluationDetails
 {
-    /** @var string */
-    private $key;
-    /** @var string|null */
-    private $variationId;
-    /** @var mixed */
-    private $value;
-    /** @var User|null */
-    private $user;
-    /** @var bool */
-    private $isDefaultValue;
-    /** @var string */
-    private $error;
-    /** @var int */
-    private $fetchTimeUnixSeconds;
-    /** @var array|null */
-    private $matchedEvaluationRule;
-    /** @var array|null */
-    private $matchedEvaluationPercentageRule;
-
     /**
      * @internal
      */
     public function __construct(
-        string $key,
-        ?string $variationId,
-        $value,
-        ?User $user,
-        bool $isDefaultValue,
-        ?string $error,
-        int $fetchTimeUnixSeconds,
-        ?array $matchedEvaluationRule,
-        ?array $matchedEvaluationPercentageRule
+        private readonly string $key,
+        private readonly ?string $variationId,
+        private readonly mixed $value,
+        private readonly ?User $user,
+        private readonly bool $isDefaultValue,
+        private readonly ?string $error,
+        private readonly int $fetchTimeUnixSeconds,
+        private readonly ?array $matchedEvaluationRule,
+        private readonly ?array $matchedEvaluationPercentageRule
     ) {
-        $this->key = $key;
-        $this->variationId = $variationId;
-        $this->value = $value;
-        $this->user = $user;
-        $this->isDefaultValue = $isDefaultValue;
-        $this->error = $error;
-        $this->fetchTimeUnixSeconds = $fetchTimeUnixSeconds;
-        $this->matchedEvaluationRule = $matchedEvaluationRule;
-        $this->matchedEvaluationPercentageRule = $matchedEvaluationPercentageRule;
     }
 
     /**
      * @internal
      */
-    public static function fromError(string $key, $value, ?User $user, string $error): EvaluationDetails
+    public static function fromError(string $key, $value, ?User $user, string $error): self
     {
-        return new EvaluationDetails(
+        return new self(
             $key,
             null,
             $value,
@@ -67,7 +39,7 @@ class EvaluationDetails
     }
 
     /**
-     * @return string the key of the evaluated feature flag or setting.
+     * @return string the key of the evaluated feature flag or setting
      */
     public function getKey(): string
     {
@@ -75,7 +47,7 @@ class EvaluationDetails
     }
 
     /**
-     * @return string the variation ID (analytics)
+     * @return string|null the variation ID (analytics)
      */
     public function getVariationId(): ?string
     {
@@ -83,15 +55,15 @@ class EvaluationDetails
     }
 
     /**
-     * @return mixed the evaluated value of the feature flag or setting.
+     * @return mixed the evaluated value of the feature flag or setting
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }
 
     /**
-     * @return User the user object that was used for evaluation.
+     * @return User|null the user object that was used for evaluation
      */
     public function getUser(): ?User
     {
@@ -99,7 +71,7 @@ class EvaluationDetails
     }
 
     /**
-     * @return bool true when the default value passed to getValueDetails() is returned due to an error.
+     * @return bool true when the default value passed to getValueDetails() is returned due to an error
      */
     public function isDefaultValue(): bool
     {
@@ -107,7 +79,7 @@ class EvaluationDetails
     }
 
     /**
-     * @return string in case of an error, the error message.
+     * @return string|null in case of an error, the error message
      */
     public function getError(): ?string
     {
@@ -115,7 +87,7 @@ class EvaluationDetails
     }
 
     /**
-     * @return int the last download time of the current config in unix seconds format.
+     * @return int the last download time of the current config in unix seconds format
      */
     public function getFetchTimeUnixSeconds(): int
     {
@@ -123,7 +95,7 @@ class EvaluationDetails
     }
 
     /**
-     * @return array the targeting rule the evaluation was based on.
+     * @return array|null the targeting rule the evaluation was based on
      */
     public function getMatchedEvaluationRule(): ?array
     {
@@ -131,7 +103,7 @@ class EvaluationDetails
     }
 
     /**
-     * @return array the percentage rule the evaluation was based on.
+     * @return array|null the percentage rule the evaluation was based on
      */
     public function getMatchedEvaluationPercentageRule(): ?array
     {

--- a/src/EvaluationLogCollector.php
+++ b/src/EvaluationLogCollector.php
@@ -5,10 +5,9 @@ namespace ConfigCat;
 /**
  * @internal
  */
-class EvaluationLogCollector
+class EvaluationLogCollector implements \Stringable
 {
-    /** @var array */
-    private $entries = [];
+    private array $entries = [];
 
     public function add($entry): void
     {
@@ -17,6 +16,6 @@ class EvaluationLogCollector
 
     public function __toString(): string
     {
-        return join(PHP_EOL, $this->entries);
+        return implode(\PHP_EOL, $this->entries);
     }
 }

--- a/src/EvaluationResult.php
+++ b/src/EvaluationResult.php
@@ -7,16 +7,7 @@ namespace ConfigCat;
  */
 final class EvaluationResult
 {
-    public $value;
-    public $variationId;
-    public $targetingRule;
-    public $percentageRule;
-
-    public function __construct($value, string $variationId, ?array $targetingRule, ?array $percentageRule)
+    public function __construct(public $value, public string $variationId, public ?array $targetingRule, public ?array $percentageRule)
     {
-        $this->value = $value;
-        $this->variationId = $variationId;
-        $this->targetingRule = $targetingRule;
-        $this->percentageRule = $percentageRule;
     }
 }

--- a/src/FetchResponse.php
+++ b/src/FetchResponse.php
@@ -4,111 +4,92 @@ namespace ConfigCat;
 
 /**
  * Represents a fetch response, including its state and body.
- * @package ConfigCat
+ *
  * @internal
  */
 final class FetchResponse
 {
     /** @var int */
-    const FETCHED = 0;
+    public const FETCHED = 0;
     /** @var int */
-    const NOT_MODIFIED = 1;
+    public const NOT_MODIFIED = 1;
     /** @var int */
-    const FAILED = 3;
+    public const FAILED = 3;
 
-    /** @var array|null */
-    private $body;
-    /** @var int */
-    private $status;
-    /** @var string|null */
-    private $etag;
-    /** @var string */
-    private $url;
-    /** @var string|null */
-    private $error;
-
-    private function __construct(
-        int $status,
-        ?string $etag = null,
-        ?array $body = null,
-        ?string $url = null,
-        ?string $error = null
-    ) {
-        $this->status = $status;
-        $this->body = $body;
-        $this->etag = $etag;
-        $this->url = $url;
-        $this->error = $error;
+    private function __construct(private readonly int $status, private readonly ?string $etag = null, private readonly ?array $body = null, private readonly ?string $url = null, private readonly ?string $error = null)
+    {
     }
 
     /**
      * Creates a new response with FAILED status.
      *
-     * @param string $error the reason of the failure.
-     * @return FetchResponse the response.
+     * @param string $error the reason of the failure
+     *
+     * @return FetchResponse the response
      */
-    public static function failure(string $error): FetchResponse
+    public static function failure(string $error): self
     {
-        return new FetchResponse(self::FAILED, null, null, null, $error);
+        return new self(self::FAILED, null, null, null, $error);
     }
 
     /**
      * Creates a new response with NOT_MODIFIED status.
      *
-     * @return FetchResponse the response.
+     * @return FetchResponse the response
      */
-    public static function notModified(): FetchResponse
+    public static function notModified(): self
     {
-        return new FetchResponse(self::NOT_MODIFIED, null, null, null, null);
+        return new self(self::NOT_MODIFIED, null, null, null, null);
     }
 
     /**
      * Creates a new response with FETCHED status.
      *
-     * @param string|null $etag the ETag.
-     * @param array $body the response body.
-     * @param string $url the fetched url.
-     * @return FetchResponse the response.
+     * @param string|null $etag the ETag
+     * @param array       $body the response body
+     * @param string      $url  the fetched url
+     *
+     * @return FetchResponse the response
      */
-    public static function success(?string $etag, array $body, string $url): FetchResponse
+    public static function success(?string $etag, array $body, string $url): self
     {
-        return new FetchResponse(self::FETCHED, $etag, $body, $url, null);
+        return new self(self::FETCHED, $etag, $body, $url, null);
     }
 
     /**
      * Returns true when the response is in fetched state.
      *
-     * @return bool True if the fetch succeeded, otherwise false.
+     * @return bool true if the fetch succeeded, otherwise false
      */
     public function isFetched(): bool
     {
-        return $this->status === self::FETCHED;
+        return self::FETCHED === $this->status;
     }
 
     /**
      * Returns true when the response is in not modified state.
      *
-     * @return bool True if the fetched configurations was not modified, otherwise false.
+     * @return bool true if the fetched configurations was not modified, otherwise false
      */
     public function isNotModified(): bool
     {
-        return $this->status === self::NOT_MODIFIED;
+        return self::NOT_MODIFIED === $this->status;
     }
 
     /**
      * Returns true when the response is in failed state.
      *
-     * @return bool True if the fetch failed, otherwise false.
+     * @return bool true if the fetch failed, otherwise false
      */
     public function isFailed(): bool
     {
-        return $this->status === self::FAILED;
+        return self::FAILED === $this->status;
     }
 
     /**
      * Returns the response body.
      *
-     * @return array|null The fetched response body.
+     * @return array|null the fetched response body
      */
     public function getBody(): ?array
     {
@@ -118,7 +99,7 @@ final class FetchResponse
     /**
      * Returns the ETag.
      *
-     * @return string|null The received ETag.
+     * @return string|null the received ETag
      */
     public function getETag(): ?string
     {
@@ -128,7 +109,7 @@ final class FetchResponse
     /**
      * Returns the proper cdn url.
      *
-     * @return string|null The cdn url.
+     * @return string|null the cdn url
      */
     public function getUrl(): ?string
     {
@@ -138,7 +119,7 @@ final class FetchResponse
     /**
      * Returns the error if the fetch failed.
      *
-     * @return string|null The error.
+     * @return string|null the error
      */
     public function getError(): ?string
     {

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -4,22 +4,18 @@ namespace ConfigCat;
 
 /**
  * Events fired by ConfigCatClient.
- * @package ConfigCat
  */
 final class Hooks
 {
-    /** @var array */
-    private $onConfigChanged = [];
-    /** @var array */
-    private $onFlagEvaluated = [];
-    /** @var array */
-    private $onError = [];
+    private array $onConfigChanged = [];
+    private array $onFlagEvaluated = [];
+    private array $onError = [];
 
     /**
      * This event is sent when the SDK loads a valid config.json into memory from cache,
      * and each subsequent time when the loaded config.json changes via HTTP.
      */
-    public function addOnConfigChanged(callable $callback)
+    public function addOnConfigChanged(callable $callback): void
     {
         $this->onConfigChanged[] = $callback;
     }
@@ -28,7 +24,7 @@ final class Hooks
      * This event is sent each time when the SDK evaluates a feature flag or setting. The event sends
      * the same evaluation details that you would get from [ConfigCatClient.getValueDetails].
      */
-    public function addOnFlagEvaluated(callable $callback)
+    public function addOnFlagEvaluated(callable $callback): void
     {
         $this->onFlagEvaluated[] = $callback;
     }
@@ -36,7 +32,7 @@ final class Hooks
     /**
      * This event is sent when an error occurs within the SDK.
      */
-    public function addOnError(callable $callback)
+    public function addOnError(callable $callback): void
     {
         $this->onError[] = $callback;
     }
@@ -44,30 +40,30 @@ final class Hooks
     /**
      * @internal
      */
-    public function fireOnConfigChanged(array $settings)
+    public function fireOnConfigChanged(array $settings): void
     {
         foreach ($this->onConfigChanged as $callback) {
-            call_user_func($callback, $settings);
+            \call_user_func($callback, $settings);
         }
     }
 
     /**
      * @internal
      */
-    public function fireOnFlagEvaluated(EvaluationDetails $details)
+    public function fireOnFlagEvaluated(EvaluationDetails $details): void
     {
         foreach ($this->onFlagEvaluated as $callback) {
-            call_user_func($callback, $details);
+            \call_user_func($callback, $details);
         }
     }
 
     /**
      * @internal
      */
-    public function fireOnError(string $error)
+    public function fireOnError(string $error): void
     {
         foreach ($this->onError as $callback) {
-            call_user_func($callback, $error);
+            \call_user_func($callback, $error);
         }
     }
 }

--- a/src/Log/InternalLogger.php
+++ b/src/Log/InternalLogger.php
@@ -8,34 +8,17 @@ use Psr\Log\LoggerInterface;
 /**
  * A Psr\Log\LoggerInterface for internal use only.
  * It handles the ConfigCat SDK specific log level and custom log entry filters.
- * @package ConfigCat
+ *
  * @internal
  */
 class InternalLogger implements LoggerInterface
 {
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-    /**
-     * @var int
-     */
-    private $globalLevel;
-    /**
-     * @var array
-     */
-    private $exceptionsToIgnore;
-    /**
-     * @var Hooks
-     */
-    private $hooks;
-
-    public function __construct(LoggerInterface $logger, $globalLevel, array $exceptionsToIgnore, Hooks $hooks)
-    {
-        $this->logger = $logger;
-        $this->globalLevel = $globalLevel;
-        $this->exceptionsToIgnore = $exceptionsToIgnore;
-        $this->hooks = $hooks;
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly int $globalLevel,
+        private readonly array $exceptionsToIgnore,
+        private readonly Hooks $hooks
+    ) {
     }
 
     public function emergency($message, array $context = []): void
@@ -105,11 +88,7 @@ class InternalLogger implements LoggerInterface
 
     private function shouldLog($currentLevel, array $context): bool
     {
-        if ($currentLevel >= $this->globalLevel && !$this->hasAnythingToIgnore($context)) {
-            return true;
-        }
-
-        return false;
+        return $currentLevel >= $this->globalLevel && !$this->hasAnythingToIgnore($context);
     }
 
     private function hasAnythingToIgnore(array $context): bool
@@ -120,10 +99,6 @@ class InternalLogger implements LoggerInterface
             return false;
         }
 
-        if (in_array(get_class($context['exception']), $this->exceptionsToIgnore)) {
-            return true;
-        }
-
-        return false;
+        return \in_array($context['exception']::class, $this->exceptionsToIgnore);
     }
 }

--- a/src/Log/LogLevel.php
+++ b/src/Log/LogLevel.php
@@ -4,34 +4,33 @@ namespace ConfigCat\Log;
 
 /**
  * Determines the current log level of the ConfigCat SDK.
- * @package ConfigCat
  */
 class LogLevel
 {
-    const DEBUG = 10;
-    const INFO = 20;
-    const NOTICE = 30;
-    const WARNING = 40;
-    const ERROR = 50;
-    const CRITICAL = 60;
-    const ALERT = 70;
-    const EMERGENCY = 80;
-    const NO_LOG = 90;
+    final public const DEBUG = 10;
+    final public const INFO = 20;
+    final public const NOTICE = 30;
+    final public const WARNING = 40;
+    final public const ERROR = 50;
+    final public const CRITICAL = 60;
+    final public const ALERT = 70;
+    final public const EMERGENCY = 80;
+    final public const NO_LOG = 90;
 
     public static function isValid($level): bool
     {
-        if (!is_int($level)) {
+        if (!\is_int($level)) {
             return false;
         }
 
-        return $level == self::DEBUG ||
-            $level == self::INFO ||
-            $level == self::NOTICE ||
-            $level == self::WARNING ||
-            $level == self::ERROR ||
-            $level == self::CRITICAL ||
-            $level == self::ALERT ||
-            $level == self::EMERGENCY ||
-            $level == self::NO_LOG;
+        return self::DEBUG == $level ||
+            self::INFO == $level ||
+            self::NOTICE == $level ||
+            self::WARNING == $level ||
+            self::ERROR == $level ||
+            self::CRITICAL == $level ||
+            self::ALERT == $level ||
+            self::EMERGENCY == $level ||
+            self::NO_LOG == $level;
     }
 }

--- a/src/Override/ArrayDataSource.php
+++ b/src/Override/ArrayDataSource.php
@@ -3,42 +3,35 @@
 namespace ConfigCat\Override;
 
 use ConfigCat\Attributes\SettingAttributes;
-use InvalidArgumentException;
 
 /**
  * Describes an array override data source.
- * @package ConfigCat
  */
 class ArrayDataSource extends OverrideDataSource
 {
-    /** @var array */
-    private $overrides;
-
     /**
      * Constructs an array data source.
-     * @param $overrides array The array that contains the overrides.
+     *
+     * @param $overrides array The array that contains the overrides
      */
-    public function __construct(array $overrides)
+    public function __construct(private readonly array $overrides)
     {
-        if (!is_array($overrides)) {
-            throw new InvalidArgumentException("The overrides is not a valid array.");
-        }
-
-        $this->overrides = $overrides;
     }
 
     /**
      * Gets the overrides.
-     * @return array The overrides.
+     *
+     * @return array the overrides
      */
     public function getOverrides(): array
     {
         $result = [];
         foreach ($this->overrides as $key => $value) {
             $result[$key] = [
-                SettingAttributes::VALUE => $value
+                SettingAttributes::VALUE => $value,
             ];
         }
+
         return $result;
     }
 }

--- a/src/Override/FlagOverrides.php
+++ b/src/Override/FlagOverrides.php
@@ -11,31 +11,29 @@ use Psr\Log\LoggerInterface;
  */
 class FlagOverrides implements LoggerAwareInterface
 {
-    /** @var int */
-    private $behaviour;
-    /** @var OverrideDataSource */
-    private $dataSource;
+    private readonly int $behaviour;
 
     /**
      * Constructs the feature flag overrides.
-     * @param $dataSource OverrideDataSource The data source of the feature flag overrides.
+     *
+     * @param $dataSource OverrideDataSource The data source of the feature flag overrides
      * @param $behaviour int It can be used to set preference on whether the local values should
      *                       override the remote values, or use local values only when a remote value doesn't exist,
-     *                       or use it for local only mode.
+     *                       or use it for local only mode
      */
-    public function __construct(OverrideDataSource $dataSource, int $behaviour)
+    public function __construct(private readonly OverrideDataSource $dataSource, int $behaviour)
     {
         if (!OverrideBehaviour::isValid($behaviour)) {
-            throw new InvalidArgumentException("The behaviour argument is not valid.");
+            throw new InvalidArgumentException('The behaviour argument is not valid.');
         }
 
         $this->behaviour = $behaviour;
-        $this->dataSource = $dataSource;
     }
 
     /**
      * Gets the override behaviour.
-     * @return int The override behaviour.
+     *
+     * @return int the override behaviour
      */
     public function getBehaviour(): int
     {
@@ -44,7 +42,8 @@ class FlagOverrides implements LoggerAwareInterface
 
     /**
      * Gets the override data source.
-     * @return OverrideDataSource The override data source.
+     *
+     * @return OverrideDataSource the override data source
      */
     public function getDataSource(): OverrideDataSource
     {
@@ -53,7 +52,8 @@ class FlagOverrides implements LoggerAwareInterface
 
     /**
      * Sets the logger.
-     * @param LoggerInterface $logger The logger.
+     *
+     * @param LoggerInterface $logger the logger
      */
     public function setLogger(LoggerInterface $logger): void
     {

--- a/src/Override/LocalFileDataSource.php
+++ b/src/Override/LocalFileDataSource.php
@@ -8,21 +8,20 @@ use InvalidArgumentException;
 
 /**
  * Describes a local file override data source.
- * @package ConfigCat
  */
 class LocalFileDataSource extends OverrideDataSource
 {
-    /** @var string */
-    private $filePath;
+    private readonly string $filePath;
 
     /**
      * Constructs a local file data source.
-     * @param $filePath string The path to the file.
+     *
+     * @param $filePath string The path to the file
      */
     public function __construct(string $filePath)
     {
         if (!file_exists($filePath)) {
-            throw new InvalidArgumentException("The file '" . $filePath . "' doesn't exist.");
+            throw new InvalidArgumentException("The file '".$filePath."' doesn't exist.");
         }
 
         $this->filePath = $filePath;
@@ -30,21 +29,24 @@ class LocalFileDataSource extends OverrideDataSource
 
     /**
      * Gets the overrides.
-     * @return array The overrides.
+     *
+     * @return array|null the overrides
      */
     public function getOverrides(): ?array
     {
         $content = file_get_contents($this->filePath);
-        if ($content === false) {
-            $this->logger->error("Could not read the contents of the file " . $this->filePath . ".");
+        if (false === $content) {
+            $this->logger->error('Could not read the contents of the file '.$this->filePath.'.');
+
             return null;
         }
 
         $json = json_decode($content, true);
 
-        if ($json == null) {
-            $this->logger->error("Could not decode json from file " . $this->filePath . ". JSON error: 
-                " . json_last_error_msg() . "");
+        if (null == $json) {
+            $this->logger->error('Could not decode json from file '.$this->filePath.'. JSON error:
+                '.json_last_error_msg().'');
+
             return null;
         }
 
@@ -52,11 +54,13 @@ class LocalFileDataSource extends OverrideDataSource
             $result = [];
             foreach ($json['flags'] as $key => $value) {
                 $result[$key] = [
-                    SettingAttributes::VALUE => $value
+                    SettingAttributes::VALUE => $value,
                 ];
             }
+
             return $result;
         }
+
         return $json[Config::ENTRIES];
     }
 }

--- a/src/Override/OverrideBehaviour.php
+++ b/src/Override/OverrideBehaviour.php
@@ -4,7 +4,6 @@ namespace ConfigCat\Override;
 
 /**
  * Describes how the overrides should behave.
- * @package ConfigCat
  */
 class OverrideBehaviour
 {
@@ -12,33 +11,31 @@ class OverrideBehaviour
      * When evaluating values, the SDK will not use feature flags & settings from the ConfigCat CDN, but it will use
      * all feature flags & settings that are loaded from local-override sources.
      */
-    const LOCAL_ONLY = 10;
+    final public const LOCAL_ONLY = 10;
     /**
      * When evaluating values, the SDK will use all feature flags & settings that are downloaded from the ConfigCat CDN,
      * plus all feature flags & settings that are loaded from local-override sources. If a feature flag or a setting is
      * defined both in the fetched and the local-override source then the local-override version will take precedence.
      */
-    const LOCAL_OVER_REMOTE = 20;
+    final public const LOCAL_OVER_REMOTE = 20;
     /**
      * When evaluating values, the SDK will use all feature flags & settings that are downloaded from the ConfigCat CDN,
      * plus all feature flags & settings that are loaded from local-override sources. If a feature flag or a setting is
      * defined both in the fetched and the local-override source then the fetched version will take precedence.
      */
-    const REMOTE_OVER_LOCAL = 30;
+    final public const REMOTE_OVER_LOCAL = 30;
 
     /**
      * Checks whether a given value is a valid behaviour.
-     * @param $behaviour int The behaviour value to check.
-     * @return bool True when the given value is a valid override behaviour.
+     *
+     * @param $behaviour int The behaviour value to check
+     *
+     * @return bool true when the given value is a valid override behaviour
      */
     public static function isValid(int $behaviour): bool
     {
-        if (!is_int($behaviour)) {
-            return false;
-        }
-
-        return $behaviour == self::LOCAL_ONLY ||
-            $behaviour == self::LOCAL_OVER_REMOTE ||
-            $behaviour == self::REMOTE_OVER_LOCAL;
+        return self::LOCAL_ONLY == $behaviour ||
+            self::LOCAL_OVER_REMOTE == $behaviour ||
+            self::REMOTE_OVER_LOCAL == $behaviour;
     }
 }

--- a/src/Override/OverrideDataSource.php
+++ b/src/Override/OverrideDataSource.php
@@ -7,44 +7,48 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Describes an override data source.
- * @package ConfigCat
  */
 abstract class OverrideDataSource implements LoggerAwareInterface
 {
-    /** @var LoggerInterface */
-    protected $logger;
+    protected LoggerInterface $logger;
 
     /**
      * Gets the overrides.
-     * @return array The overrides.
+     *
+     * @return array|null the overrides
      */
     abstract public function getOverrides(): ?array;
 
     /**
      * Sets the logger.
-     * @param LoggerInterface $logger The logger.
+     *
+     * @param LoggerInterface $logger the logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
 
     /**
      * Creates an override data source that reads the overrides from a file.
-     * @param $filePath string The path to the file.
-     * @return OverrideDataSource The constructed data source.
+     *
+     * @param $filePath string The path to the file
+     *
+     * @return OverrideDataSource the constructed data source
      */
-    public static function localFile(string $filePath): OverrideDataSource
+    public static function localFile(string $filePath): self
     {
         return new LocalFileDataSource($filePath);
     }
 
     /**
      * Creates an override data source that reads the overrides from an array.
-     * @param $overrides array The array that contains the overrides.
-     * @return OverrideDataSource The constructed data source.
+     *
+     * @param $overrides array The array that contains the overrides
+     *
+     * @return OverrideDataSource the constructed data source
      */
-    public static function localArray(array $overrides): OverrideDataSource
+    public static function localArray(array $overrides): self
     {
         return new ArrayDataSource($overrides);
     }

--- a/src/Pair.php
+++ b/src/Pair.php
@@ -4,32 +4,18 @@ namespace ConfigCat;
 
 /**
  * Represents a simple key-value pair.
- * @package ConfigCat
  */
 class Pair
 {
-    /** @var string The key. */
-    private $key;
-
-    /** @var mixed The value. */
-    private $value;
-
     /**
      * Creates a new Pair.
-     *
-     * @param string $key The key.
-     * @param mixed $value The value:
      */
-    public function __construct(string $key, $value)
+    public function __construct(private readonly string $key, private readonly mixed $value)
     {
-        $this->key = $key;
-        $this->value = $value;
     }
 
     /**
      * Gets the key.
-     *
-     * @return string
      */
     public function getKey(): string
     {
@@ -38,10 +24,8 @@ class Pair
 
     /**
      * Gets the value.
-     *
-     * @return mixed
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }

--- a/src/RefreshResult.php
+++ b/src/RefreshResult.php
@@ -7,26 +7,17 @@ namespace ConfigCat;
  */
 class RefreshResult
 {
-    /** @var bool */
-    private $isSuccess;
-    /** @var string|null */
-    private $error;
-
     /**
-     * @param bool $isSuccess
-     * @param string|null $error
      * @internal
      */
-    public function __construct(bool $isSuccess, ?string $error)
+    public function __construct(private readonly bool $isSuccess, private readonly ?string $error)
     {
-        $this->isSuccess = $isSuccess;
-        $this->error = $error;
     }
 
     /**
      * Returns true when the refresh was successful.
      *
-     * @return bool true when the refresh was successful.
+     * @return bool true when the refresh was successful
      */
     public function isSuccess(): bool
     {
@@ -36,7 +27,7 @@ class RefreshResult
     /**
      * Returns the reason if the refresh fails.
      *
-     * @return string|null the reason of the failure.
+     * @return string|null the reason of the failure
      */
     public function getError(): ?string
     {

--- a/src/RolloutEvaluator.php
+++ b/src/RolloutEvaluator.php
@@ -7,58 +7,55 @@ use ConfigCat\Attributes\RolloutAttributes;
 use ConfigCat\Attributes\SettingAttributes;
 use Exception;
 use Psr\Log\LoggerInterface;
-use z4kn4fein\SemVer\Version;
 use z4kn4fein\SemVer\SemverException;
+use z4kn4fein\SemVer\Version;
 
 /**
- * Class RolloutEvaluator
- * @package ConfigCat
+ * Class RolloutEvaluator.
+ *
  * @internal
  */
 final class RolloutEvaluator
 {
-    /** @var LoggerInterface */
-    private $logger;
-
-    private $comparatorTexts = [
-        "IS ONE OF",
-        "IS NOT ONE OF",
-        "CONTAINS",
-        "DOES NOT CONTAIN",
-        "IS ONE OF (SemVer)",
-        "IS NOT ONE OF (SemVer)",
-        "< (SemVer)",
-        "<= (SemVer)",
-        "> (SemVer)",
-        ">= (SemVer)",
-        "= (Number)",
-        "<> (Number)",
-        "< (Number)",
-        "<= (Number)",
-        "> (Number)",
-        ">= (Number)",
-        "IS ONE OF (Sensitive)",
-        "IS NOT ONE OF (Sensitive)"
+    private array $comparatorTexts = [
+        'IS ONE OF',
+        'IS NOT ONE OF',
+        'CONTAINS',
+        'DOES NOT CONTAIN',
+        'IS ONE OF (SemVer)',
+        'IS NOT ONE OF (SemVer)',
+        '< (SemVer)',
+        '<= (SemVer)',
+        '> (SemVer)',
+        '>= (SemVer)',
+        '= (Number)',
+        '<> (Number)',
+        '< (Number)',
+        '<= (Number)',
+        '> (Number)',
+        '>= (Number)',
+        'IS ONE OF (Sensitive)',
+        'IS NOT ONE OF (Sensitive)',
     ];
 
     /**
      * RolloutEvaluator constructor.
      *
-     * @param LoggerInterface $logger The logger instance.
+     * @param LoggerInterface $logger the logger instance
      */
-    public function __construct(LoggerInterface $logger)
+    public function __construct(private readonly LoggerInterface $logger)
     {
-        $this->logger = $logger;
     }
 
     /**
      * Evaluates a requested value from the configuration by the specified roll-out rules.
      *
-     * @param string $key The key of the desired value.
-     * @param array $json The decoded JSON configuration.
-     * @param EvaluationLogCollector $logCollector The evaluation log collector.
-     * @param User|null $user Optional. The user to identify the caller.
-     * @return EvaluationResult The evaluation result.
+     * @param string                 $key          the key of the desired value
+     * @param array                  $json         the decoded JSON configuration
+     * @param EvaluationLogCollector $logCollector the evaluation log collector
+     * @param User|null              $user         Optional. The user to identify the caller.
+     *
+     * @return EvaluationResult the evaluation result
      */
     public function evaluate(
         string $key,
@@ -66,30 +63,31 @@ final class RolloutEvaluator
         EvaluationLogCollector $logCollector,
         User $user = null
     ): EvaluationResult {
-        if (is_null($user)) {
+        if (null === $user) {
             if (isset($json[SettingAttributes::ROLLOUT_RULES]) &&
                 !empty($json[SettingAttributes::ROLLOUT_RULES]) ||
                 isset($json[SettingAttributes::ROLLOUT_PERCENTAGE_ITEMS]) &&
                 !empty($json[SettingAttributes::ROLLOUT_PERCENTAGE_ITEMS])) {
-                $this->logger->warning("UserObject missing! You should pass a " .
-                    "UserObject to getValue() in order to make targeting work properly. " .
-                    "Read more: https://configcat.com/docs/advanced/user-object.");
+                $this->logger->warning('UserObject missing! You should pass a '.
+                    'UserObject to getValue() in order to make targeting work properly. '.
+                    'Read more: https://configcat.com/docs/advanced/user-object.');
             }
 
             $result = $json[SettingAttributes::VALUE];
-            $variationId = $json[SettingAttributes::VARIATION_ID] ?? "";
-            $logCollector->add("Returning " . Utils::getStringRepresentation($result) . ".");
+            $variationId = $json[SettingAttributes::VARIATION_ID] ?? '';
+            $logCollector->add('Returning '.Utils::getStringRepresentation($result).'.');
+
             return new EvaluationResult($result, $variationId, null, null);
         }
 
-        $logCollector->add("User object: " . $user);
+        $logCollector->add('User object: '.$user);
         if (isset($json[SettingAttributes::ROLLOUT_RULES]) && !empty($json[SettingAttributes::ROLLOUT_RULES])) {
             foreach ($json[SettingAttributes::ROLLOUT_RULES] as $rule) {
                 $comparisonAttribute = $rule[RolloutAttributes::COMPARISON_ATTRIBUTE];
                 $comparisonValue = $rule[RolloutAttributes::COMPARISON_VALUE];
                 $comparator = $rule[RolloutAttributes::COMPARATOR];
                 $value = $rule[RolloutAttributes::VALUE];
-                $variationId = $rule[RolloutAttributes::VARIATION_ID] ?? "";
+                $variationId = $rule[RolloutAttributes::VARIATION_ID] ?? '';
                 $userValue = $user->getAttribute($comparisonAttribute);
 
                 if (empty($comparisonValue) || (!is_numeric($userValue) && empty($userValue))) {
@@ -103,10 +101,10 @@ final class RolloutEvaluator
                 }
 
                 switch ($comparator) {
-                    //IS ONE OF
+                    // IS ONE OF
                     case 0:
                         $split = array_filter(Utils::splitTrim($comparisonValue));
-                        if (in_array($userValue, $split, true)) {
+                        if (\in_array($userValue, $split, true)) {
                             $logCollector->add($this->logMatch(
                                 $comparisonAttribute,
                                 $userValue,
@@ -114,13 +112,14 @@ final class RolloutEvaluator
                                 $comparisonValue,
                                 $value
                             ));
+
                             return new EvaluationResult($value, $variationId, $rule, null);
                         }
                         break;
-                    //IS NOT ONE OF
+                        // IS NOT ONE OF
                     case 1:
                         $split = array_filter(Utils::splitTrim($comparisonValue));
-                        if (!in_array($userValue, $split, true)) {
+                        if (!\in_array($userValue, $split, true)) {
                             $logCollector->add($this->logMatch(
                                 $comparisonAttribute,
                                 $userValue,
@@ -128,10 +127,11 @@ final class RolloutEvaluator
                                 $comparisonValue,
                                 $value
                             ));
+
                             return new EvaluationResult($value, $variationId, $rule, null);
                         }
                         break;
-                    //CONTAINS
+                        // CONTAINS
                     case 2:
                         if (Utils::strContains($userValue, $comparisonValue)) {
                             $logCollector->add($this->logMatch(
@@ -141,10 +141,11 @@ final class RolloutEvaluator
                                 $comparisonValue,
                                 $value
                             ));
+
                             return new EvaluationResult($value, $variationId, $rule, null);
                         }
                         break;
-                    //DOES NOT CONTAIN
+                        // DOES NOT CONTAIN
                     case 3:
                         if (!Utils::strContains($userValue, $comparisonValue)) {
                             $logCollector->add($this->logMatch(
@@ -154,10 +155,11 @@ final class RolloutEvaluator
                                 $comparisonValue,
                                 $value
                             ));
+
                             return new EvaluationResult($value, $variationId, $rule, null);
                         }
                         break;
-                    //IS ONE OF, IS NOT ONE OF (SemVer)
+                        // IS ONE OF, IS NOT ONE OF (SemVer)
                     case 4:
                     case 5:
                         $split = array_filter(Utils::splitTrim($comparisonValue));
@@ -167,7 +169,7 @@ final class RolloutEvaluator
                                 $matched = Version::equal($userValue, $semVer) || $matched;
                             }
 
-                            if (($matched && $comparator == 4) || (!$matched && $comparator == 5)) {
+                            if (($matched && 4 == $comparator) || (!$matched && 5 == $comparator)) {
                                 $logCollector->add($this->logMatch(
                                     $comparisonAttribute,
                                     $userValue,
@@ -175,6 +177,7 @@ final class RolloutEvaluator
                                     $comparisonValue,
                                     $value
                                 ));
+
                                 return new EvaluationResult($value, $variationId, $rule, null);
                             }
                         } catch (SemverException $exception) {
@@ -189,19 +192,19 @@ final class RolloutEvaluator
                         }
 
                         break;
-                    //LESS THAN, LESS THAN OR EQUALS TO, GREATER THAN, GREATER THAN OR EQUALS TO (SemVer)
+                        // LESS THAN, LESS THAN OR EQUALS TO, GREATER THAN, GREATER THAN OR EQUALS TO (SemVer)
                     case 6:
                     case 7:
                     case 8:
                     case 9:
                         try {
-                            if (($comparator == 6 &&
+                            if ((6 == $comparator &&
                                     Version::lessThan($userValue, $comparisonValue)) ||
-                                ($comparator == 7 &&
+                                (7 == $comparator &&
                                     Version::lessThanOrEqual($userValue, $comparisonValue)) ||
-                                ($comparator == 8 &&
+                                (8 == $comparator &&
                                     Version::greaterThan($userValue, $comparisonValue)) ||
-                                ($comparator == 9 &&
+                                (9 == $comparator &&
                                     Version::greaterThanOrEqual($userValue, $comparisonValue))) {
                                 $logCollector->add($this->logMatch(
                                     $comparisonAttribute,
@@ -210,6 +213,7 @@ final class RolloutEvaluator
                                     $comparisonValue,
                                     $value
                                 ));
+
                                 return new EvaluationResult($value, $variationId, $rule, null);
                             }
                         } catch (SemverException $exception) {
@@ -223,22 +227,22 @@ final class RolloutEvaluator
                             break;
                         }
                         break;
-                    //LESS THAN, LESS THAN OR EQUALS TO, GREATER THAN, GREATER THAN OR EQUALS TO (Number)
+                        // LESS THAN, LESS THAN OR EQUALS TO, GREATER THAN, GREATER THAN OR EQUALS TO (Number)
                     case 10:
                     case 11:
                     case 12:
                     case 13:
                     case 14:
                     case 15:
-                        $userDouble = str_replace(",", ".", $userValue);
-                        $comparisonDouble = str_replace(",", ".", $comparisonValue);
+                        $userDouble = str_replace(',', '.', $userValue);
+                        $comparisonDouble = str_replace(',', '.', (string) $comparisonValue);
                         if (!is_numeric($userDouble)) {
                             $logCollector->add($this->logFormatErrorWithMessage(
                                 $comparisonAttribute,
                                 $userValue,
                                 $comparator,
                                 $comparisonValue,
-                                $userDouble . "is not a valid number."
+                                $userDouble.'is not a valid number.'
                             ));
                             break;
                         }
@@ -249,20 +253,20 @@ final class RolloutEvaluator
                                 $userValue,
                                 $comparator,
                                 $comparisonValue,
-                                $comparisonDouble . "is not a valid number."
+                                $comparisonDouble.'is not a valid number.'
                             ));
                             break;
                         }
 
-                        $userDoubleValue = floatval($userDouble);
-                        $comparisonDoubleValue = floatval($comparisonDouble);
+                        $userDoubleValue = (float) $userDouble;
+                        $comparisonDoubleValue = (float) $comparisonDouble;
 
-                        if (($comparator == 10 && $userDoubleValue == $comparisonDoubleValue) ||
-                            ($comparator == 11 && $userDoubleValue != $comparisonDoubleValue) ||
-                            ($comparator == 12 && $userDoubleValue < $comparisonDoubleValue) ||
-                            ($comparator == 13 && $userDoubleValue <= $comparisonDoubleValue) ||
-                            ($comparator == 14 && $userDoubleValue > $comparisonDoubleValue) ||
-                            ($comparator == 15 && $userDoubleValue >= $comparisonDoubleValue)) {
+                        if ((10 == $comparator && $userDoubleValue === $comparisonDoubleValue) ||
+                            (11 == $comparator && $userDoubleValue !== $comparisonDoubleValue) ||
+                            (12 == $comparator && $userDoubleValue < $comparisonDoubleValue) ||
+                            (13 == $comparator && $userDoubleValue <= $comparisonDoubleValue) ||
+                            (14 == $comparator && $userDoubleValue > $comparisonDoubleValue) ||
+                            (15 == $comparator && $userDoubleValue >= $comparisonDoubleValue)) {
                             $logCollector->add($this->logMatch(
                                 $comparisonAttribute,
                                 $userValue,
@@ -270,13 +274,14 @@ final class RolloutEvaluator
                                 $comparisonValue,
                                 $value
                             ));
+
                             return new EvaluationResult($value, $variationId, $rule, null);
                         }
                         break;
-                    //IS ONE OF (Sensitive)
+                        // IS ONE OF (Sensitive)
                     case 16:
                         $split = array_filter(Utils::splitTrim($comparisonValue));
-                        if (in_array(sha1($userValue), $split, true)) {
+                        if (\in_array(sha1($userValue), $split, true)) {
                             $logCollector->add($this->logMatch(
                                 $comparisonAttribute,
                                 $userValue,
@@ -284,13 +289,14 @@ final class RolloutEvaluator
                                 $comparisonValue,
                                 $value
                             ));
+
                             return new EvaluationResult($value, $variationId, $rule, null);
                         }
                         break;
-                    //IS NOT ONE OF (Sensitive)
+                        // IS NOT ONE OF (Sensitive)
                     case 17:
                         $split = array_filter(Utils::splitTrim($comparisonValue));
-                        if (!in_array(sha1($userValue), $split, true)) {
+                        if (!\in_array(sha1($userValue), $split, true)) {
                             $logCollector->add($this->logMatch(
                                 $comparisonAttribute,
                                 $userValue,
@@ -298,6 +304,7 @@ final class RolloutEvaluator
                                 $comparisonValue,
                                 $value
                             ));
+
                             return new EvaluationResult($value, $variationId, $rule, null);
                         }
                         break;
@@ -308,9 +315,9 @@ final class RolloutEvaluator
 
         if (isset($json[SettingAttributes::ROLLOUT_PERCENTAGE_ITEMS]) &&
             !empty($json[SettingAttributes::ROLLOUT_PERCENTAGE_ITEMS])) {
-            $hashCandidate = $key . $user->getIdentifier();
+            $hashCandidate = $key.$user->getIdentifier();
             $stringHash = substr(sha1($hashCandidate), 0, 7);
-            $intHash = intval($stringHash, 16);
+            $intHash = \intval($stringHash, 16);
             $scale = $intHash % 100;
 
             $bucket = 0;
@@ -320,31 +327,33 @@ final class RolloutEvaluator
                     $result = $rule[PercentageAttributes::VALUE];
                     $variationId = $rule[PercentageAttributes::VARIATION_ID];
                     $logCollector->add(
-                        "Evaluating % options. Returning " . Utils::getStringRepresentation($result) . "."
+                        'Evaluating % options. Returning '.Utils::getStringRepresentation($result).'.'
                     );
+
                     return new EvaluationResult($result, $variationId, null, $rule);
                 }
             }
         }
 
         $result = $json[SettingAttributes::VALUE];
-        $variationId = $json[SettingAttributes::VARIATION_ID] ?? "";
-        $logCollector->add("Returning " . Utils::getStringRepresentation($result) . ".");
+        $variationId = $json[SettingAttributes::VARIATION_ID] ?? '';
+        $logCollector->add('Returning '.Utils::getStringRepresentation($result).'.');
+
         return new EvaluationResult($result, $variationId, null, null);
     }
 
     private function logMatch($comparisonAttribute, $userValue, $comparator, $comparisonValue, $value): string
     {
-        return "Evaluating rule: [" . $comparisonAttribute . ":" . $userValue . "] " .
-            "[" . $this->comparatorTexts[$comparator] . "] " .
-            "[" . $comparisonValue . "] => match, returning: " . Utils::getStringRepresentation($value) . ".";
+        return 'Evaluating rule: ['.$comparisonAttribute.':'.$userValue.'] '.
+            '['.$this->comparatorTexts[$comparator].'] '.
+            '['.$comparisonValue.'] => match, returning: '.Utils::getStringRepresentation($value).'.';
     }
 
     private function logNoMatch($comparisonAttribute, $userValue, $comparator, $comparisonValue): string
     {
-        return "Evaluating rule: [" . $comparisonAttribute . ":" . $userValue . "] " .
-            "[" . $this->comparatorTexts[$comparator] . "] " .
-            "[" . $comparisonValue . "] => no match.";
+        return 'Evaluating rule: ['.$comparisonAttribute.':'.$userValue.'] '.
+            '['.$this->comparatorTexts[$comparator].'] '.
+            '['.$comparisonValue.'] => no match.';
     }
 
     private function logFormatError(
@@ -354,10 +363,11 @@ final class RolloutEvaluator
         $comparisonValue,
         Exception $exception
     ): string {
-        $message = "Evaluating rule: [" . $comparisonAttribute . ":" . $userValue . "] " .
-            "[" . $this->comparatorTexts[$comparator] . "] " .
-            "[" . $comparisonValue . "] => SKIP rule. Validation error: " . $exception->getMessage() . ".";
+        $message = 'Evaluating rule: ['.$comparisonAttribute.':'.$userValue.'] '.
+            '['.$this->comparatorTexts[$comparator].'] '.
+            '['.$comparisonValue.'] => SKIP rule. Validation error: '.$exception->getMessage().'.';
         $this->logger->warning($message, ['exception' => $exception]);
+
         return $message;
     }
 
@@ -368,10 +378,11 @@ final class RolloutEvaluator
         $comparisonValue,
         $message
     ): string {
-        $message = "Evaluating rule: [" . $comparisonAttribute . ":" . $userValue . "] " .
-            "[" . $this->comparatorTexts[$comparator] . "] " .
-            "[" . $comparisonValue . "] => SKIP rule. Validation error: " . $message . ".";
+        $message = 'Evaluating rule: ['.$comparisonAttribute.':'.$userValue.'] '.
+            '['.$this->comparatorTexts[$comparator].'] '.
+            '['.$comparisonValue.'] => SKIP rule. Validation error: '.$message.'.';
         $this->logger->warning($message);
+
         return $message;
     }
 }

--- a/src/SettingsResult.php
+++ b/src/SettingsResult.php
@@ -7,14 +7,7 @@ namespace ConfigCat;
  */
 class SettingsResult
 {
-    /** @var array */
-    public $settings;
-    /** @var int */
-    public $fetchTime;
-
-    public function __construct(array $settings, int $fetchTime)
+    public function __construct(public array $settings, public int $fetchTime)
     {
-        $this->settings = $settings;
-        $this->fetchTime = $fetchTime;
     }
 }

--- a/src/User.php
+++ b/src/User.php
@@ -2,26 +2,25 @@
 
 namespace ConfigCat;
 
+use JsonException;
+
 /**
  * An object containing attributes to properly identify a given user for rollout evaluation.
- * @package ConfigCat
  */
-final class User
+final class User implements \Stringable
 {
-    /** @var array */
-    private $attributes = [];
-    /** @var string */
-    private $identifier;
+    private array $attributes = [];
+    private readonly string $identifier;
 
     /**
      * User constructor.
      *
-     * @param string $identifier The identifier of the user.
-     * @param string $email Optional. The email of the user.
-     * @param string $country Optional. The country attribute of the user.
-     * @param array $custom Custom user attributes.
+     * @param string $identifier the identifier of the user
+     * @param string $email      Optional. The email of the user.
+     * @param string $country    Optional. The country attribute of the user.
+     * @param array  $custom     custom user attributes
      */
-    public function __construct(string $identifier, string $email = "", string $country = "", array $custom = [])
+    public function __construct(string $identifier, string $email = '', string $country = '', array $custom = [])
     {
         $this->identifier = $this->attributes['Identifier'] = $identifier;
 
@@ -41,7 +40,7 @@ final class User
     /**
      * Gets the identifier of the user.
      *
-     * @return string The identifier of the user.
+     * @return string the identifier of the user
      */
     public function getIdentifier(): string
     {
@@ -51,19 +50,22 @@ final class User
     /**
      * Gets a user attribute identified by the given key.
      *
-     * @param string $key The key of the user attribute.
-     * @return string|null The user attribute, or null if it doesn't exist.
+     * @param string $key the key of the user attribute
+     *
+     * @return string|null the user attribute, or null if it doesn't exist
      */
     public function getAttribute(string $key): ?string
     {
-        return array_key_exists($key, $this->attributes) ? $this->attributes[$key] : null;
+        return $this->attributes[$key] ?? null;
     }
 
     /**
-     * @return string The string representation of the user.
+     * @return string the string representation of the user
+     *
+     * @throws JsonException
      */
     public function __toString(): string
     {
-        return json_encode($this->attributes);
+        return json_encode($this->attributes, \JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -4,7 +4,7 @@ namespace ConfigCat;
 
 /**
  * Contains helper utility operations.
- * @package ConfigCat
+ *
  * @internal
  */
 final class Utils
@@ -12,21 +12,23 @@ final class Utils
     /**
      * Determines that a string contains an other.
      *
-     * @param string $haystack The string in we search for the other.
-     * @param string $needle The string we search.
-     * @return bool True if the $haystack contains the $needle.
+     * @param string $haystack the string in we search for the other
+     * @param string $needle   the string we search
+     *
+     * @return bool true if the $haystack contains the $needle
      */
     public static function strContains(string $haystack, string $needle): bool
     {
-        return strpos($haystack, $needle) !== false;
+        return str_contains($haystack, $needle);
     }
 
     /**
      * Splits a given string and trims the result items.
      *
-     * @param string $text The text to split and trim.
-     * @param string $delimiter The delimiter.
-     * @return array The array of split items.
+     * @param string $text      the text to split and trim
+     * @param string $delimiter the delimiter
+     *
+     * @return array the array of split items
      */
     public static function splitTrim(string $text, string $delimiter = ','): array
     {
@@ -36,15 +38,16 @@ final class Utils
     /**
      * Returns the string representation of a value.
      *
-     * @param mixed $value The value.
-     * @return string The result string.
+     * @param mixed $value the value
+     *
+     * @return string the result string
      */
-    public static function getStringRepresentation($value): string
+    public static function getStringRepresentation(mixed $value): string
     {
-        if (is_bool($value) === true) {
-            return $value ? "true" : "false";
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
         }
 
-        return (string)$value;
+        return (string) $value;
     }
 }

--- a/tests/ConfigCatClientTest.php
+++ b/tests/ConfigCatClientTest.php
@@ -23,12 +23,12 @@ use ReflectionException;
 
 class ConfigCatClientTest extends TestCase
 {
-    private const TEST_JSON = "{ \"f\" : { \"first\": { \"v\": false, \"p\": [], \"r\": [], \"i\":\"fakeIdFirst\" }, \"second\": { \"v\": true, \"p\": [], \"r\": [], \"i\":\"fakeIdSecond\" }}}";
+    private const TEST_JSON = '{ "f" : { "first": { "v": false, "p": [], "r": [], "i":"fakeIdFirst" }, "second": { "v": true, "p": [], "r": [], "i":"fakeIdSecond" }}}';
 
     public function testConstructEmptySdkKey()
     {
         $this->expectException(InvalidArgumentException::class);
-        new ConfigCatClient("");
+        new ConfigCatClient('');
     }
 
     /**
@@ -36,15 +36,15 @@ class ConfigCatClientTest extends TestCase
      */
     public function testConstructDefaults()
     {
-        $client = new ConfigCatClient("testConstructDefaults");
+        $client = new ConfigCatClient('testConstructDefaults');
 
-        $logger = $this->getReflectedValue($client, "logger");
+        $logger = $this->getReflectedValue($client, 'logger');
         $this->assertInstanceOf(InternalLogger::class, $logger);
 
-        $cache = $this->getReflectedValue($client, "cache");
+        $cache = $this->getReflectedValue($client, 'cache');
         $this->assertInstanceOf(ArrayCache::class, $cache);
 
-        $cacheRefreshInterval = $this->getReflectedValue($client, "cacheRefreshInterval");
+        $cacheRefreshInterval = $this->getReflectedValue($client, 'cacheRefreshInterval');
         $this->assertEquals(60, $cacheRefreshInterval);
     }
 
@@ -54,16 +54,16 @@ class ConfigCatClientTest extends TestCase
     public function testConstructLoggerOption()
     {
         $logger = new NullLogger();
-        $client = new ConfigCatClient("testConstructLoggerOption", [
+        $client = new ConfigCatClient('testConstructLoggerOption', [
             ClientOptions::LOGGER => $logger,
             ClientOptions::LOG_LEVEL => LogLevel::ERROR,
-            ClientOptions::EXCEPTIONS_TO_IGNORE => [InvalidArgumentException::class]
+            ClientOptions::EXCEPTIONS_TO_IGNORE => [InvalidArgumentException::class],
         ]);
-        $internalLogger = $this->getReflectedValue($client, "logger");
+        $internalLogger = $this->getReflectedValue($client, 'logger');
 
-        $externalLogger = $this->getReflectedValue($internalLogger, "logger");
-        $globalLevel = $this->getReflectedValue($internalLogger, "globalLevel");
-        $exceptions = $this->getReflectedValue($internalLogger, "exceptionsToIgnore");
+        $externalLogger = $this->getReflectedValue($internalLogger, 'logger');
+        $globalLevel = $this->getReflectedValue($internalLogger, 'globalLevel');
+        $exceptions = $this->getReflectedValue($internalLogger, 'exceptionsToIgnore');
 
         $this->assertSame($logger, $externalLogger);
         $this->assertSame(LogLevel::ERROR, $globalLevel);
@@ -73,30 +73,30 @@ class ConfigCatClientTest extends TestCase
     public function testConstructCacheOption()
     {
         $cache = new ArrayCache();
-        $client = new ConfigCatClient("testConstructCacheOption", [ClientOptions::CACHE => $cache]);
-        $this->assertAttributeSame($cache, "cache", $client);
+        $client = new ConfigCatClient('testConstructCacheOption', [ClientOptions::CACHE => $cache]);
+        $this->assertAttributeSame($cache, 'cache', $client);
     }
 
     public function testConstructCacheRefreshIntervalOption()
     {
-        $client = new ConfigCatClient("testConstructCacheRefreshIntervalOption", [ClientOptions::CACHE_REFRESH_INTERVAL => 20]);
-        $this->assertAttributeSame(20, "cacheRefreshInterval", $client);
+        $client = new ConfigCatClient('testConstructCacheRefreshIntervalOption', [ClientOptions::CACHE_REFRESH_INTERVAL => 20]);
+        $this->assertAttributeSame(20, 'cacheRefreshInterval', $client);
     }
 
     public function testGetValueFailedFetch()
     {
-        $client = new ConfigCatClient("testGetValueFailedFetch", [ClientOptions::CUSTOM_HANDLER => new MockHandler([
-            new Response(400)
+        $client = new ConfigCatClient('testGetValueFailedFetch', [ClientOptions::CUSTOM_HANDLER => new MockHandler([
+            new Response(400),
         ])]);
 
-        $value = $client->getValue("key", false);
+        $value = $client->getValue('key', false);
         $this->assertFalse($value);
     }
 
     public function testGetAllKeysFailedFetch()
     {
-        $client = new ConfigCatClient("testGetAllKeysFailedFetch", [ClientOptions::CUSTOM_HANDLER => new MockHandler([
-            new Response(400)
+        $client = new ConfigCatClient('testGetAllKeysFailedFetch', [ClientOptions::CUSTOM_HANDLER => new MockHandler([
+            new Response(400),
         ])]);
 
         $keys = $client->getAllKeys();
@@ -106,64 +106,64 @@ class ConfigCatClientTest extends TestCase
     public function testForceRefresh()
     {
         $cache = $this->getMockBuilder(ConfigCache::class)->getMock();
-        $client = new ConfigCatClient("PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA",
+        $client = new ConfigCatClient('PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA',
             [ClientOptions::CACHE => $cache]);
 
         $cache
             ->expects(self::once())
-            ->method("store");
+            ->method('store');
 
         $client->forceRefresh();
     }
 
     public function testKeyNotExist()
     {
-        $client = new ConfigCatClient("PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA");
-        $value = $client->getValue("nonExistingKey", false);
+        $client = new ConfigCatClient('PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA');
+        $value = $client->getValue('nonExistingKey', false);
 
         $this->assertFalse($value);
     }
 
     public function testGetVariationId()
     {
-        $client = new ConfigCatClient("testGetVariationId", [
+        $client = new ConfigCatClient('testGetVariationId', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler(
                 [new Response(200, [], self::TEST_JSON)]
             ),
         ]);
-        $value = $client->getVariationId("second", null);
+        $value = $client->getVariationId('second', null);
 
-        $this->assertEquals("fakeIdSecond", $value);
+        $this->assertEquals('fakeIdSecond', $value);
     }
 
     public function testGetVariationIdDefault()
     {
-        $client = new ConfigCatClient("testGetVariationIdDefault", [
+        $client = new ConfigCatClient('testGetVariationIdDefault', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler(
                 [new Response(200, [], self::TEST_JSON)]
             ),
         ]);
-        $value = $client->getVariationId("nonexisting", null);
+        $value = $client->getVariationId('nonexisting', null);
 
         $this->assertNull($value);
     }
 
     public function testGetAllVariationIds()
     {
-        $client = new ConfigCatClient("testGetAllVariationIds", [
+        $client = new ConfigCatClient('testGetAllVariationIds', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler(
                 [new Response(200, [], self::TEST_JSON)]
             ),
         ]);
         $value = $client->getAllVariationIds();
 
-        $this->assertEquals(["fakeIdFirst", "fakeIdSecond"], $value);
+        $this->assertEquals(['fakeIdFirst', 'fakeIdSecond'], $value);
     }
 
     public function testGetAllVariationIdsEmpty()
     {
-        $client = new ConfigCatClient("testGetAllVariationIdsEmpty", [ClientOptions::CUSTOM_HANDLER => new MockHandler([
-            new Response(400)
+        $client = new ConfigCatClient('testGetAllVariationIdsEmpty', [ClientOptions::CUSTOM_HANDLER => new MockHandler([
+            new Response(400),
         ])]);
         $value = $client->getAllVariationIds();
 
@@ -172,108 +172,108 @@ class ConfigCatClientTest extends TestCase
 
     public function testGetKeyAndValue()
     {
-        $client = new ConfigCatClient("testGetKeyAndValue", [
+        $client = new ConfigCatClient('testGetKeyAndValue', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler(
                 [new Response(200, [], self::TEST_JSON)]
             ),
         ]);
-        $value = $client->getKeyAndValue("fakeIdSecond");
+        $value = $client->getKeyAndValue('fakeIdSecond');
 
-        $this->assertEquals("second", $value->getKey());
+        $this->assertEquals('second', $value->getKey());
         $this->assertTrue($value->getValue());
     }
 
     public function testGetKeyAndValueNull()
     {
-        $client = new ConfigCatClient("testGetKeyAndValueNull", [
+        $client = new ConfigCatClient('testGetKeyAndValueNull', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler(
                 [new Response(200, [], self::TEST_JSON)]
             ),
         ]);
-        $value = $client->getKeyAndValue("nonexisting");
+        $value = $client->getKeyAndValue('nonexisting');
 
         $this->assertNull($value);
     }
 
     public function testGetAllValues()
     {
-        $client = new ConfigCatClient("testGetAllValues", [
+        $client = new ConfigCatClient('testGetAllValues', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler(
                 [new Response(200, [], self::TEST_JSON)]
             ),
         ]);
         $value = $client->getAllValues();
 
-        $this->assertEquals(["first" => false, "second" => true], $value);
+        $this->assertEquals(['first' => false, 'second' => true], $value);
     }
 
     public function testDefaultUser()
     {
-        $client = new ConfigCatClient("testDefaultUser", [ClientOptions::CUSTOM_HANDLER => new MockHandler([
-            new Response(200, [], Utils::formatConfigWithRules())
+        $client = new ConfigCatClient('testDefaultUser', [ClientOptions::CUSTOM_HANDLER => new MockHandler([
+            new Response(200, [], Utils::formatConfigWithRules()),
         ])]);
 
-        $user1 = new User("test@test1.com");
-        $user2 = new User("test@test2.com");
+        $user1 = new User('test@test1.com');
+        $user2 = new User('test@test2.com');
 
         $client->setDefaultUser($user1);
 
-        $value = $client->getValue("key", "");
-        $this->assertEquals("fake1", $value);
+        $value = $client->getValue('key', '');
+        $this->assertEquals('fake1', $value);
 
-        $value = $client->getValue("key", "", $user2);
-        $this->assertEquals("fake2", $value);
+        $value = $client->getValue('key', '', $user2);
+        $this->assertEquals('fake2', $value);
 
         $client->clearDefaultUser();
 
-        $value = $client->getValue("key", "");
-        $this->assertEquals("def", $value);
+        $value = $client->getValue('key', '');
+        $this->assertEquals('def', $value);
     }
 
     public function testInitDefaultUser()
     {
-        $client = new ConfigCatClient("testInitDefaultUser",
+        $client = new ConfigCatClient('testInitDefaultUser',
             [
                 ClientOptions::CUSTOM_HANDLER => new MockHandler([new Response(200, [], Utils::formatConfigWithRules())]),
-                ClientOptions::DEFAULT_USER => new User("test@test1.com")
+                ClientOptions::DEFAULT_USER => new User('test@test1.com'),
             ]
         );
 
-        $user2 = new User("test@test2.com");
+        $user2 = new User('test@test2.com');
 
-        $value = $client->getValue("key", "");
-        $this->assertEquals("fake1", $value);
+        $value = $client->getValue('key', '');
+        $this->assertEquals('fake1', $value);
 
-        $value = $client->getValue("key", "", $user2);
-        $this->assertEquals("fake2", $value);
+        $value = $client->getValue('key', '', $user2);
+        $this->assertEquals('fake2', $value);
 
         $client->clearDefaultUser();
 
-        $value = $client->getValue("key", "");
-        $this->assertEquals("def", $value);
+        $value = $client->getValue('key', '');
+        $this->assertEquals('def', $value);
     }
 
     public function testDefaultUserVariationId()
     {
-        $client = new ConfigCatClient("testDefaultUserVariationId", [ClientOptions::CUSTOM_HANDLER => new MockHandler([
-            new Response(200, [], Utils::formatConfigWithRules())
+        $client = new ConfigCatClient('testDefaultUserVariationId', [ClientOptions::CUSTOM_HANDLER => new MockHandler([
+            new Response(200, [], Utils::formatConfigWithRules()),
         ])]);
 
-        $user1 = new User("test@test1.com");
-        $user2 = new User("test@test2.com");
+        $user1 = new User('test@test1.com');
+        $user2 = new User('test@test2.com');
 
         $client->setDefaultUser($user1);
 
-        $value = $client->getVariationId("key", "");
-        $this->assertEquals("id1", $value);
+        $value = $client->getVariationId('key', '');
+        $this->assertEquals('id1', $value);
 
-        $value = $client->getVariationId("key", "", $user2);
-        $this->assertEquals("id2", $value);
+        $value = $client->getVariationId('key', '', $user2);
+        $this->assertEquals('id2', $value);
 
         $client->clearDefaultUser();
 
-        $value = $client->getVariationId("key", "");
-        $this->assertEquals("defVar", $value);
+        $value = $client->getVariationId('key', '');
+        $this->assertEquals('defVar', $value);
     }
 
     public function testOfflineOnline()
@@ -286,7 +286,7 @@ class ConfigCatClientTest extends TestCase
             ]
         );
 
-        $client = new ConfigCatClient("testOfflineOnline", [
+        $client = new ConfigCatClient('testOfflineOnline', [
             ClientOptions::CUSTOM_HANDLER => $handler,
         ]);
 
@@ -319,9 +319,9 @@ class ConfigCatClientTest extends TestCase
             ]
         );
 
-        $client = new ConfigCatClient("testInitOfflineOnline", [
+        $client = new ConfigCatClient('testInitOfflineOnline', [
             ClientOptions::CUSTOM_HANDLER => $handler,
-            ClientOptions::OFFLINE => true
+            ClientOptions::OFFLINE => true,
         ]);
 
         $this->assertTrue($client->isOffline());
@@ -340,11 +340,11 @@ class ConfigCatClientTest extends TestCase
 
     public function testHooks()
     {
-        $client = new ConfigCatClient("getTestClientWithError", [
+        $client = new ConfigCatClient('getTestClientWithError', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler(
                 [
                     new Response(200, [], self::TEST_JSON),
-                    new Response(400, [], "")
+                    new Response(400, [], ''),
                 ]
             ),
         ]);
@@ -352,47 +352,46 @@ class ConfigCatClientTest extends TestCase
         $evaluated = false;
         $error = false;
         $changed = false;
-        $message = "";
-        $client->hooks()->addOnFlagEvaluated(function($details) use (&$evaluated) {
+        $message = '';
+        $client->hooks()->addOnFlagEvaluated(function ($details) use (&$evaluated) {
             $evaluated = true;
         });
-        $client->hooks()->addOnConfigChanged(function($settings) use (&$changed) {
+        $client->hooks()->addOnConfigChanged(function ($settings) use (&$changed) {
             $changed = true;
         });
-        $client->hooks()->addOnError(function($err) use (&$error, &$message) {
+        $client->hooks()->addOnError(function ($err) use (&$error, &$message) {
             $error = true;
             $message = $err;
         });
 
-        $client->getValue("first", false);
+        $client->getValue('first', false);
         $result = $client->forceRefresh();
-
 
         $this->assertTrue($evaluated);
         $this->assertTrue($error);
-        $this->assertEquals("Double-check your SDK Key at https://app.configcat.com/sdkkey. Received unexpected response: 400", $message);
+        $this->assertEquals('Double-check your SDK Key at https://app.configcat.com/sdkkey. Received unexpected response: 400', $message);
         $this->assertTrue($changed);
 
         $this->assertFalse($result->isSuccess());
-        $this->assertEquals("Double-check your SDK Key at https://app.configcat.com/sdkkey. Received unexpected response: 400", $result->getError());
+        $this->assertEquals('Double-check your SDK Key at https://app.configcat.com/sdkkey. Received unexpected response: 400', $result->getError());
     }
 
     public function testEvalDetails()
     {
-        $client = new ConfigCatClient("testEvalDetails", [ClientOptions::CUSTOM_HANDLER => new MockHandler([
-            new Response(200, [], Utils::formatConfigWithRules())
+        $client = new ConfigCatClient('testEvalDetails', [ClientOptions::CUSTOM_HANDLER => new MockHandler([
+            new Response(200, [], Utils::formatConfigWithRules()),
         ])]);
 
-        $details = $client->getValueDetails("key", "", new User("test@test1.com"));
+        $details = $client->getValueDetails('key', '', new User('test@test1.com'));
 
-        $this->assertEquals("fake1", $details->getValue());
-        $this->assertEquals("id1", $details->getVariationId());
+        $this->assertEquals('fake1', $details->getValue());
+        $this->assertEquals('id1', $details->getVariationId());
         $this->assertNull($details->getError());
-        $this->assertEquals("key", $details->getKey());
-        $this->assertEquals("test@test1.com", $details->getUser()->getIdentifier());
-        $this->assertEquals("Identifier", $details->getMatchedEvaluationRule()["a"]);
-        $this->assertEquals("@test1.com", $details->getMatchedEvaluationRule()["c"]);
-        $this->assertEquals(2, $details->getMatchedEvaluationRule()["t"]);
+        $this->assertEquals('key', $details->getKey());
+        $this->assertEquals('test@test1.com', $details->getUser()->getIdentifier());
+        $this->assertEquals('Identifier', $details->getMatchedEvaluationRule()['a']);
+        $this->assertEquals('@test1.com', $details->getMatchedEvaluationRule()['c']);
+        $this->assertEquals(2, $details->getMatchedEvaluationRule()['t']);
         $this->assertNull($details->getMatchedEvaluationPercentageRule());
         $this->assertTrue($details->getFetchTimeUnixSeconds() > 0);
         $this->assertFalse($details->isDefaultValue());
@@ -400,65 +399,65 @@ class ConfigCatClientTest extends TestCase
 
     public function testEvalDetailsHook()
     {
-        $client = new ConfigCatClient("testEvalDetailsHook", [ClientOptions::CUSTOM_HANDLER => new MockHandler([
-            new Response(200, [], Utils::formatConfigWithRules())
+        $client = new ConfigCatClient('testEvalDetailsHook', [ClientOptions::CUSTOM_HANDLER => new MockHandler([
+            new Response(200, [], Utils::formatConfigWithRules()),
         ])]);
 
         $called = false;
         $client->hooks()->addOnFlagEvaluated(function (EvaluationDetails $details) use (&$called) {
-            $this->assertEquals("fake1", $details->getValue());
-            $this->assertEquals("id1", $details->getVariationId());
+            $this->assertEquals('fake1', $details->getValue());
+            $this->assertEquals('id1', $details->getVariationId());
             $this->assertNull($details->getError());
-            $this->assertEquals("key", $details->getKey());
-            $this->assertEquals("test@test1.com", $details->getUser()->getIdentifier());
-            $this->assertEquals("Identifier", $details->getMatchedEvaluationRule()["a"]);
-            $this->assertEquals("@test1.com", $details->getMatchedEvaluationRule()["c"]);
-            $this->assertEquals(2, $details->getMatchedEvaluationRule()["t"]);
+            $this->assertEquals('key', $details->getKey());
+            $this->assertEquals('test@test1.com', $details->getUser()->getIdentifier());
+            $this->assertEquals('Identifier', $details->getMatchedEvaluationRule()['a']);
+            $this->assertEquals('@test1.com', $details->getMatchedEvaluationRule()['c']);
+            $this->assertEquals(2, $details->getMatchedEvaluationRule()['t']);
             $this->assertNull($details->getMatchedEvaluationPercentageRule());
             $this->assertFalse($details->isDefaultValue());
             $this->assertTrue($details->getFetchTimeUnixSeconds() > 0);
             $called = true;
         });
 
-        $client->getValue("key", "", new User("test@test1.com"));
+        $client->getValue('key', '', new User('test@test1.com'));
 
         $this->assertTrue($called);
     }
 
     public function testTimeout()
     {
-        $client = new ConfigCatClient("testTimout", [
+        $client = new ConfigCatClient('testTimout', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler([
-                new ConnectException("timeout", new Request("GET", "test"))
+                new ConnectException('timeout', new Request('GET', 'test')),
             ]),
         ]);
-        $value = $client->getValue("test", "def");
+        $value = $client->getValue('test', 'def');
 
-        $this->assertEquals("def", $value);
+        $this->assertEquals('def', $value);
     }
 
     public function testHttpException()
     {
-        $client = new ConfigCatClient("testHttpException", [
+        $client = new ConfigCatClient('testHttpException', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler([
-                new RequestException("failed", new Request("GET", "test"))
+                new RequestException('failed', new Request('GET', 'test')),
             ]),
         ]);
-        $value = $client->getValue("test", "def");
+        $value = $client->getValue('test', 'def');
 
-        $this->assertEquals("def", $value);
+        $this->assertEquals('def', $value);
     }
 
     public function testGeneralException()
     {
-        $client = new ConfigCatClient("testGeneralException", [
+        $client = new ConfigCatClient('testGeneralException', [
             ClientOptions::CUSTOM_HANDLER => new MockHandler([
-                new Exception("failed")
+                new Exception('failed'),
             ]),
         ]);
-        $value = $client->getValue("test", "def");
+        $value = $client->getValue('test', 'def');
 
-        $this->assertEquals("def", $value);
+        $this->assertEquals('def', $value);
     }
 
     /**
@@ -469,6 +468,7 @@ class ConfigCatClientTest extends TestCase
         $reflection = new \ReflectionClass($object);
         $property = $reflection->getProperty($propertyName);
         $property->setAccessible(true);
+
         return $property->getValue($object);
     }
 }

--- a/tests/ConfigFetcherTest.php
+++ b/tests/ConfigFetcherTest.php
@@ -16,30 +16,30 @@ use Psr\Log\NullLogger;
 
 class ConfigFetcherTest extends TestCase
 {
-    private $mockSdkKey = "testSdkKey";
-    private $mockEtag = "testEtag";
-    private $mockBody = "{\"key\": \"value\"}";
+    private string $mockSdkKey = 'testSdkKey';
+    private string $mockEtag = 'testEtag';
+    private string $mockBody = '{"key": "value"}';
 
     public function testFetchOk()
     {
         $fetcher = new ConfigFetcher($this->mockSdkKey, Utils::getTestLogger(), [ClientOptions::CUSTOM_HANDLER => HandlerStack::create(new MockHandler([
-            new Response(200, [ConfigFetcher::ETAG_HEADER => $this->mockEtag], $this->mockBody)
+            new Response(200, [ConfigFetcher::ETAG_HEADER => $this->mockEtag], $this->mockBody),
         ]))]);
 
-        $response = $fetcher->fetch("old_etag", "");
+        $response = $fetcher->fetch('old_etag', '');
 
         $this->assertTrue($response->isFetched());
         $this->assertEquals($this->mockEtag, $response->getETag());
-        $this->assertEquals("value", $response->getBody()['key']);
+        $this->assertEquals('value', $response->getBody()['key']);
     }
 
     public function testFetchNotModified()
     {
         $fetcher = new ConfigFetcher($this->mockSdkKey, Utils::getTestLogger(), [ClientOptions::CUSTOM_HANDLER => HandlerStack::create(new MockHandler([
-            new Response(304, [ConfigFetcher::ETAG_HEADER => $this->mockEtag])
+            new Response(304, [ConfigFetcher::ETAG_HEADER => $this->mockEtag]),
         ]))]);
 
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         $this->assertTrue($response->isNotModified());
         $this->assertNull($response->getETag());
@@ -49,10 +49,10 @@ class ConfigFetcherTest extends TestCase
     public function testFetchFailed()
     {
         $fetcher = new ConfigFetcher($this->mockSdkKey, Utils::getTestLogger(), [ClientOptions::CUSTOM_HANDLER => HandlerStack::create(new MockHandler([
-            new Response(400)
+            new Response(400),
         ]))]);
 
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         $this->assertTrue($response->isFailed());
         $this->assertNull($response->getETag());
@@ -62,10 +62,10 @@ class ConfigFetcherTest extends TestCase
     public function testFetchInvalidJson()
     {
         $fetcher = new ConfigFetcher($this->mockSdkKey, Utils::getTestLogger(), [ClientOptions::CUSTOM_HANDLER => HandlerStack::create(new MockHandler([
-            new Response(200, [], "{\"key\": value}")
+            new Response(200, [], '{"key": value}'),
         ]))]);
 
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         $this->assertTrue($response->isFailed());
         $this->assertNull($response->getETag());
@@ -75,23 +75,23 @@ class ConfigFetcherTest extends TestCase
     public function testConstructEmptySdkKey()
     {
         $this->expectException(InvalidArgumentException::class);
-        new ConfigFetcher("", new NullLogger());
+        new ConfigFetcher('', new NullLogger());
     }
 
     public function testConstructDefaults()
     {
-        $fetcher = new ConfigFetcher("api", Utils::getTestLogger());
+        $fetcher = new ConfigFetcher('api', Utils::getTestLogger());
         $options = $fetcher->getRequestOptions();
 
         $this->assertEquals(10, $options[RequestOptions::CONNECT_TIMEOUT]);
         $this->assertEquals(30, $options[RequestOptions::TIMEOUT]);
-        $this->assertArrayHasKey("headers", $options);
+        $this->assertArrayHasKey('headers', $options);
     }
 
     public function testConstructConnectTimeoutOption()
     {
-        $fetcher = new ConfigFetcher("api", Utils::getTestLogger(), [ClientOptions::REQUEST_OPTIONS => [
-            RequestOptions::CONNECT_TIMEOUT => 5
+        $fetcher = new ConfigFetcher('api', Utils::getTestLogger(), [ClientOptions::REQUEST_OPTIONS => [
+            RequestOptions::CONNECT_TIMEOUT => 5,
         ]]);
         $options = $fetcher->getRequestOptions();
         $this->assertEquals(5, $options[RequestOptions::CONNECT_TIMEOUT]);
@@ -99,8 +99,8 @@ class ConfigFetcherTest extends TestCase
 
     public function testConstructRequestTimeoutOption()
     {
-        $fetcher = new ConfigFetcher("api", Utils::getTestLogger(), [ClientOptions::REQUEST_OPTIONS => [
-            RequestOptions::TIMEOUT => 5
+        $fetcher = new ConfigFetcher('api', Utils::getTestLogger(), [ClientOptions::REQUEST_OPTIONS => [
+            RequestOptions::TIMEOUT => 5,
         ]]);
         $options = $fetcher->getRequestOptions();
         $this->assertEquals(5, $options[RequestOptions::TIMEOUT]);
@@ -108,21 +108,21 @@ class ConfigFetcherTest extends TestCase
 
     public function testTimeoutException()
     {
-        $fetcher = new ConfigFetcher("api", Utils::getTestLogger(), [ClientOptions::CUSTOM_HANDLER => HandlerStack::create(new MockHandler([
-            new ConnectException("timeout", new Request("GET", "test"))
+        $fetcher = new ConfigFetcher('api', Utils::getTestLogger(), [ClientOptions::CUSTOM_HANDLER => HandlerStack::create(new MockHandler([
+            new ConnectException('timeout', new Request('GET', 'test')),
         ]))]);
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
         $this->assertTrue($response->isFailed());
     }
 
     public function testIntegration()
     {
-        $fetcher = new ConfigFetcher("PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA", Utils::getTestLogger());
-        $response = $fetcher->fetch("", "");
+        $fetcher = new ConfigFetcher('PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA', Utils::getTestLogger());
+        $response = $fetcher->fetch('', '');
 
         $this->assertTrue($response->isFetched());
 
-        $notModifiedResponse = $fetcher->fetch($response->getETag(), "");
+        $notModifiedResponse = $fetcher->fetch($response->getETag(), '');
 
         $this->assertTrue($notModifiedResponse->isNotModified());
     }

--- a/tests/DataGovernanceTest.php
+++ b/tests/DataGovernanceTest.php
@@ -12,70 +12,74 @@ use PHPUnit\Framework\TestCase;
 
 class DataGovernanceTest extends TestCase
 {
-    const JSON_TEMPLATE = "{ \"p\": { \"u\": \"%s\", \"r\": %d }, \"f\": {} }";
-    const CUSTOM_CDN_URL = "https://custom-cdn.configcat.com";
+    final public const JSON_TEMPLATE = '{ "p": { "u": "%s", "r": %d }, "f": {} }';
+    final public const CUSTOM_CDN_URL = 'https://custom-cdn.configcat.com';
 
-    public function testShouldStayOnServer() {
+    public function testShouldStayOnServer()
+    {
         // Arrange
         $requests = [];
-        $body = sprintf(self::JSON_TEMPLATE, "https://fakeUrl", 0);
+        $body = sprintf(self::JSON_TEMPLATE, 'https://fakeUrl', 0);
         $responses = [
-            new Response(200, [], $body)
+            new Response(200, [], $body),
         ];
 
         $handler = $this->getHandlerStack($responses, $requests);
         $fetcher = $this->getFetcher($handler);
 
         // Act
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         // Assert
-        $this->assertEquals(1, count($requests));
+        $this->assertEquals(1, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertEquals(json_decode($body, true), $response->getBody());
     }
 
-    public function testShouldStayOnSameUrlWithRedirect() {
+    public function testShouldStayOnSameUrlWithRedirect()
+    {
         // Arrange
         $requests = [];
         $body = sprintf(self::JSON_TEMPLATE, ConfigFetcher::GLOBAL_URL, 1);
         $responses = [
-            new Response(200, [], $body)
+            new Response(200, [], $body),
         ];
 
         $handler = $this->getHandlerStack($responses, $requests);
         $fetcher = $this->getFetcher($handler);
 
         // Act
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         // Assert
-        $this->assertEquals(1, count($requests));
+        $this->assertEquals(1, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertEquals(json_decode($body, true), $response->getBody());
     }
 
-    public function testShouldStayOnSameUrlEvenWhenForced() {
+    public function testShouldStayOnSameUrlEvenWhenForced()
+    {
         // Arrange
         $requests = [];
         $body = sprintf(self::JSON_TEMPLATE, ConfigFetcher::GLOBAL_URL, 2);
         $responses = [
-            new Response(200, [], $body)
+            new Response(200, [], $body),
         ];
 
         $handler = $this->getHandlerStack($responses, $requests);
         $fetcher = $this->getFetcher($handler);
 
         // Act
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         // Assert
-        $this->assertEquals(1, count($requests));
+        $this->assertEquals(1, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertEquals(json_decode($body, true), $response->getBody());
     }
 
-    public function testShouldRedirectToAnotherServer() {
+    public function testShouldRedirectToAnotherServer()
+    {
         // Arrange
         $requests = [];
         $firstBody = sprintf(self::JSON_TEMPLATE, ConfigFetcher::EU_ONLY_URL, 1);
@@ -89,16 +93,17 @@ class DataGovernanceTest extends TestCase
         $fetcher = $this->getFetcher($handler);
 
         // Act
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         // Assert
-        $this->assertEquals(2, count($requests));
+        $this->assertEquals(2, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertContains($requests[1]['request']->getUri()->getHost(), ConfigFetcher::EU_ONLY_URL);
         $this->assertEquals(json_decode($secondBody, true), $response->getBody());
     }
 
-    public function testShouldRedirectToAnotherServerWhenForced() {
+    public function testShouldRedirectToAnotherServerWhenForced()
+    {
         // Arrange
         $requests = [];
         $firstBody = sprintf(self::JSON_TEMPLATE, ConfigFetcher::EU_ONLY_URL, 2);
@@ -112,16 +117,17 @@ class DataGovernanceTest extends TestCase
         $fetcher = $this->getFetcher($handler);
 
         // Act
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         // Assert
-        $this->assertEquals(2, count($requests));
+        $this->assertEquals(2, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertContains($requests[1]['request']->getUri()->getHost(), ConfigFetcher::EU_ONLY_URL);
         $this->assertEquals(json_decode($secondBody, true), $response->getBody());
     }
 
-    public function testShouldRedirectToAnotherServerWhenWrongIsCached() {
+    public function testShouldRedirectToAnotherServerWhenWrongIsCached()
+    {
         // Arrange
         $requests = [];
         $firstBody = sprintf(self::JSON_TEMPLATE, ConfigFetcher::GLOBAL_URL, 1);
@@ -135,16 +141,17 @@ class DataGovernanceTest extends TestCase
         $fetcher = $this->getFetcher($handler);
 
         // Act
-        $response = $fetcher->fetch("", ConfigFetcher::EU_ONLY_URL);
+        $response = $fetcher->fetch('', ConfigFetcher::EU_ONLY_URL);
 
         // Assert
-        $this->assertEquals(2, count($requests));
+        $this->assertEquals(2, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), ConfigFetcher::EU_ONLY_URL);
         $this->assertContains($requests[1]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertEquals(json_decode($secondBody, true), $response->getBody());
     }
 
-    public function testShouldBreakRedirectLoop() {
+    public function testShouldBreakRedirectLoop()
+    {
         // Arrange
         $requests = [];
         $firstBody = sprintf(self::JSON_TEMPLATE, ConfigFetcher::EU_ONLY_URL, 1);
@@ -159,17 +166,18 @@ class DataGovernanceTest extends TestCase
         $fetcher = $this->getFetcher($handler);
 
         // Act
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         // Assert
-        $this->assertEquals(3, count($requests));
+        $this->assertEquals(3, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertContains($requests[1]['request']->getUri()->getHost(), ConfigFetcher::EU_ONLY_URL);
         $this->assertContains($requests[2]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertEquals(json_decode($firstBody, true), $response->getBody());
     }
 
-    public function testShouldBreakRedirectLoopWhenForced() {
+    public function testShouldBreakRedirectLoopWhenForced()
+    {
         // Arrange
         $requests = [];
         $firstBody = sprintf(self::JSON_TEMPLATE, ConfigFetcher::EU_ONLY_URL, 2);
@@ -184,60 +192,63 @@ class DataGovernanceTest extends TestCase
         $fetcher = $this->getFetcher($handler);
 
         // Act
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         // Assert
-        $this->assertEquals(3, count($requests));
+        $this->assertEquals(3, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertContains($requests[1]['request']->getUri()->getHost(), ConfigFetcher::EU_ONLY_URL);
         $this->assertContains($requests[2]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertEquals(json_decode($firstBody, true), $response->getBody());
     }
 
-    public function testShouldRespectCustomUrlWhenNotForced() {
+    public function testShouldRespectCustomUrlWhenNotForced()
+    {
         // Arrange
         $requests = [];
         $firstBody = sprintf(self::JSON_TEMPLATE, ConfigFetcher::GLOBAL_URL, 1);
         $responses = [
-            new Response(200, [], $firstBody)
+            new Response(200, [], $firstBody),
         ];
 
         $handler = $this->getHandlerStack($responses, $requests);
         $fetcher = $this->getFetcher($handler, self::CUSTOM_CDN_URL);
 
         // Act
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         // Assert
-        $this->assertEquals(1, count($requests));
+        $this->assertEquals(1, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), self::CUSTOM_CDN_URL);
         $this->assertEquals(json_decode($firstBody, true), $response->getBody());
     }
 
-    public function testShouldNotRespectCustomUrlWhenForced() {
+    public function testShouldNotRespectCustomUrlWhenForced()
+    {
         // Arrange
         $requests = [];
         $firstBody = sprintf(self::JSON_TEMPLATE, ConfigFetcher::GLOBAL_URL, 2);
         $secondBody = sprintf(self::JSON_TEMPLATE, ConfigFetcher::GLOBAL_URL, 0);
         $responses = [
             new Response(200, [], $firstBody),
-            new Response(200, [], $secondBody)
+            new Response(200, [], $secondBody),
         ];
 
         $handler = $this->getHandlerStack($responses, $requests);
         $fetcher = $this->getFetcher($handler, self::CUSTOM_CDN_URL);
 
         // Act
-        $response = $fetcher->fetch("", "");
+        $response = $fetcher->fetch('', '');
 
         // Assert
-        $this->assertEquals(2, count($requests));
+        $this->assertEquals(2, is_countable($requests) ? \count($requests) : 0);
         $this->assertContains($requests[0]['request']->getUri()->getHost(), self::CUSTOM_CDN_URL);
         $this->assertContains($requests[1]['request']->getUri()->getHost(), ConfigFetcher::GLOBAL_URL);
         $this->assertEquals(json_decode($secondBody, true), $response->getBody());
     }
 
-    private function getHandlerStack(array $responses, array &$container = []) {
+    private function getHandlerStack(array $responses, array &$container = [])
+    {
         $history = Middleware::history($container);
         $stack = HandlerStack::create(new MockHandler($responses));
         $stack->push($history);
@@ -245,10 +256,11 @@ class DataGovernanceTest extends TestCase
         return $stack;
     }
 
-    private function getFetcher($handler, $customUrl = "") {
-        return new ConfigFetcher("fakeKey", Utils::getTestLogger(), [
+    private function getFetcher($handler, $customUrl = '')
+    {
+        return new ConfigFetcher('fakeKey', Utils::getTestLogger(), [
             ClientOptions::CUSTOM_HANDLER => $handler,
-            ClientOptions::BASE_URL => $customUrl
+            ClientOptions::BASE_URL => $customUrl,
         ]);
     }
 }

--- a/tests/LocalSourceTest.php
+++ b/tests/LocalSourceTest.php
@@ -10,86 +10,93 @@ use ConfigCat\Override\OverrideDataSource;
 use ConfigCat\User;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit\Framework\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 class LocalSourceTest extends TestCase
 {
-    const TEST_JSON_BODY = "{ \"f\" : { \"disabled\": { \"v\": false, \"p\": [], \"r\": [], \"i\":\"fakeIdFirst\" }, \"enabled\": { \"v\": true, \"p\": [], \"r\": [], \"i\":\"fakeIdSecond\" }}}";
+    final public const TEST_JSON_BODY = '{ "f" : { "disabled": { "v": false, "p": [], "r": [], "i":"fakeIdFirst" }, "enabled": { "v": true, "p": [], "r": [], "i":"fakeIdSecond" }}}';
 
-    public function testWithNonExistingFile() {
+    public function testWithNonExistingFile()
+    {
         $this->expectException(InvalidArgumentException::class);
-        new ConfigCatClient("testWithNonExistingFile", [
-            ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localFile("non-existing"), OverrideBehaviour::LOCAL_ONLY),
+        new ConfigCatClient('testWithNonExistingFile', [
+            ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localFile('non-existing'), OverrideBehaviour::LOCAL_ONLY),
         ]);
     }
 
-    public function testWithInvalidBehavior() {
+    public function testWithInvalidBehavior()
+    {
         $this->expectException(InvalidArgumentException::class);
-        new ConfigCatClient("testWithInvalidBehavior", [
+        new ConfigCatClient('testWithInvalidBehavior', [
             ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localArray([]), 50),
         ]);
     }
 
-    public function testWithFile() {
-        $client = new ConfigCatClient("testWithFile", [
-            ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localFile("tests/test.json"), OverrideBehaviour::LOCAL_ONLY),
+    public function testWithFile()
+    {
+        $client = new ConfigCatClient('testWithFile', [
+            ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localFile('tests/test.json'), OverrideBehaviour::LOCAL_ONLY),
         ]);
 
-        $this->assertTrue($client->getValue("enabledFeature", false));
-        $this->assertFalse($client->getValue("disabledFeature", true));
-        $this->assertEquals(5, $client->getValue("intSetting", 0));
-        $this->assertEquals(3.14, $client->getValue("doubleSetting", 0.0));
-        $this->assertEquals("test", $client->getValue("stringSetting", 0));
+        $this->assertTrue($client->getValue('enabledFeature', false));
+        $this->assertFalse($client->getValue('disabledFeature', true));
+        $this->assertEquals(5, $client->getValue('intSetting', 0));
+        $this->assertEquals(3.14, $client->getValue('doubleSetting', 0.0));
+        $this->assertEquals('test', $client->getValue('stringSetting', 0));
     }
 
-    public function testWithFile_Rules() {
-        $client = new ConfigCatClient("testWithFile_Rules", [
-            ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localFile("tests/test-rules.json"), OverrideBehaviour::LOCAL_ONLY),
+    public function testWithFileRules()
+    {
+        $client = new ConfigCatClient('testWithFile_Rules', [
+            ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localFile('tests/test-rules.json'), OverrideBehaviour::LOCAL_ONLY),
         ]);
 
         // without user
-        $this->assertFalse($client->getValue("rolloutFeature", true));
+        $this->assertFalse($client->getValue('rolloutFeature', true));
 
         // not in rule
-        $this->assertFalse($client->getValue("rolloutFeature", true, new User("test@test.com")));
+        $this->assertFalse($client->getValue('rolloutFeature', true, new User('test@test.com')));
 
         // in rule
-        $this->assertTrue($client->getValue("rolloutFeature", false, new User("test@example.com")));
+        $this->assertTrue($client->getValue('rolloutFeature', false, new User('test@example.com')));
     }
 
-    public function testWithSimpleFile() {
-        $client = new ConfigCatClient("testWithSimpleFile", [
-            ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localFile("tests/test-simple.json"), OverrideBehaviour::LOCAL_ONLY),
+    public function testWithSimpleFile()
+    {
+        $client = new ConfigCatClient('testWithSimpleFile', [
+            ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localFile('tests/test-simple.json'), OverrideBehaviour::LOCAL_ONLY),
         ]);
 
-        $this->assertTrue($client->getValue("enabledFeature", false));
-        $this->assertFalse($client->getValue("disabledFeature", true));
-        $this->assertEquals(5, $client->getValue("intSetting", 0));
-        $this->assertEquals(3.14, $client->getValue("doubleSetting", 0.0));
-        $this->assertEquals("test", $client->getValue("stringSetting", 0));
+        $this->assertTrue($client->getValue('enabledFeature', false));
+        $this->assertFalse($client->getValue('disabledFeature', true));
+        $this->assertEquals(5, $client->getValue('intSetting', 0));
+        $this->assertEquals(3.14, $client->getValue('doubleSetting', 0.0));
+        $this->assertEquals('test', $client->getValue('stringSetting', 0));
     }
 
-    public function testWithArraySource() {
-        $client = new ConfigCatClient("testWithArraySource", [
+    public function testWithArraySource()
+    {
+        $client = new ConfigCatClient('testWithArraySource', [
             ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localArray([
                 'enabledFeature' => true,
                 'disabledFeature' => false,
                 'intSetting' => 5,
                 'doubleSetting' => 3.14,
-                'stringSetting' => "test",
+                'stringSetting' => 'test',
             ]), OverrideBehaviour::LOCAL_ONLY),
         ]);
 
-        $this->assertTrue($client->getValue("enabledFeature", false));
-        $this->assertFalse($client->getValue("disabledFeature", true));
-        $this->assertEquals(5, $client->getValue("intSetting", 0));
-        $this->assertEquals(3.14, $client->getValue("doubleSetting", 0.0));
-        $this->assertEquals("test", $client->getValue("stringSetting", 0));
+        $this->assertTrue($client->getValue('enabledFeature', false));
+        $this->assertFalse($client->getValue('disabledFeature', true));
+        $this->assertEquals(5, $client->getValue('intSetting', 0));
+        $this->assertEquals(3.14, $client->getValue('doubleSetting', 0.0));
+        $this->assertEquals('test', $client->getValue('stringSetting', 0));
     }
 
-    public function testLocalOverRemote() {
-        $client = new ConfigCatClient("testLocalOverRemote", [
+    public function testLocalOverRemote()
+    {
+        $client = new ConfigCatClient('testLocalOverRemote', [
             ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localArray([
                 'enabled' => false,
                 'nonexisting' => true,
@@ -99,12 +106,13 @@ class LocalSourceTest extends TestCase
             ),
         ]);
 
-        $this->assertTrue($client->getValue("nonexisting", false));
-        $this->assertFalse($client->getValue("enabled", true));
+        $this->assertTrue($client->getValue('nonexisting', false));
+        $this->assertFalse($client->getValue('enabled', true));
     }
 
-    public function testRemoteOverLocal() {
-        $client = new ConfigCatClient("testRemoteOverLocal", [
+    public function testRemoteOverLocal()
+    {
+        $client = new ConfigCatClient('testRemoteOverLocal', [
             ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localArray([
                 'enabled' => false,
                 'nonexisting' => true,
@@ -114,22 +122,23 @@ class LocalSourceTest extends TestCase
             ),
         ]);
 
-        $this->assertTrue($client->getValue("nonexisting", false));
-        $this->assertTrue($client->getValue("enabled", false));
+        $this->assertTrue($client->getValue('nonexisting', false));
+        $this->assertTrue($client->getValue('enabled', false));
     }
 
-    public function testLocalOnlyIgnoresFetched() {
+    public function testLocalOnlyIgnoresFetched()
+    {
         $handler = new MockHandler(
             [new Response(200, [], self::TEST_JSON_BODY)]
         );
-        $client = new ConfigCatClient("testLocalOnlyIgnoresFetched", [
+        $client = new ConfigCatClient('testLocalOnlyIgnoresFetched', [
             ClientOptions::FLAG_OVERRIDES => new FlagOverrides(OverrideDataSource::localArray([
                 'nonexisting' => true,
             ]), OverrideBehaviour::LOCAL_ONLY),
             ClientOptions::CUSTOM_HANDLER => $handler,
         ]);
 
-        $this->assertFalse($client->getValue("enabled", false));
+        $this->assertFalse($client->getValue('enabled', false));
         $this->assertEquals(1, $handler->count());
     }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -21,44 +21,44 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::once())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::once())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::once())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::once())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::once())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::once())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::once())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::once())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("");
-        $logger->alert("");
-        $logger->critical("");
-        $logger->error("");
-        $logger->notice("");
-        $logger->info("");
-        $logger->debug("");
-        $logger->warning("");
+        $logger->emergency('');
+        $logger->alert('');
+        $logger->critical('');
+        $logger->error('');
+        $logger->notice('');
+        $logger->info('');
+        $logger->debug('');
+        $logger->warning('');
     }
 
     public function testLoggerLogOnlyHigherLevelThanDebug()
@@ -69,44 +69,44 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::once())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::once())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::once())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::once())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::once())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::once())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::once())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("");
-        $logger->alert("");
-        $logger->critical("");
-        $logger->error("");
-        $logger->notice("");
-        $logger->info("");
-        $logger->debug("");
-        $logger->warning("");
+        $logger->emergency('');
+        $logger->alert('');
+        $logger->critical('');
+        $logger->error('');
+        $logger->notice('');
+        $logger->info('');
+        $logger->debug('');
+        $logger->warning('');
     }
 
     public function testLoggerLogOnlyHigherLevelThanInfo()
@@ -117,44 +117,44 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::once())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::once())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::once())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::once())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::once())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::once())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::never())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("");
-        $logger->alert("");
-        $logger->critical("");
-        $logger->error("");
-        $logger->notice("");
-        $logger->info("");
-        $logger->debug("");
-        $logger->warning("");
+        $logger->emergency('');
+        $logger->alert('');
+        $logger->critical('');
+        $logger->error('');
+        $logger->notice('');
+        $logger->info('');
+        $logger->debug('');
+        $logger->warning('');
     }
 
     public function testLoggerLogOnlyHigherLevelThanNotice()
@@ -165,44 +165,44 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::once())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::once())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::once())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::once())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::once())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::never())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::never())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("");
-        $logger->alert("");
-        $logger->critical("");
-        $logger->error("");
-        $logger->notice("");
-        $logger->info("");
-        $logger->debug("");
-        $logger->warning("");
+        $logger->emergency('');
+        $logger->alert('');
+        $logger->critical('');
+        $logger->error('');
+        $logger->notice('');
+        $logger->info('');
+        $logger->debug('');
+        $logger->warning('');
     }
 
     public function testLoggerLogOnlyHigherLevelThanWarning()
@@ -213,44 +213,44 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::once())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::once())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::once())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::once())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::never())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::never())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::never())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("");
-        $logger->alert("");
-        $logger->critical("");
-        $logger->error("");
-        $logger->notice("");
-        $logger->info("");
-        $logger->debug("");
-        $logger->warning("");
+        $logger->emergency('');
+        $logger->alert('');
+        $logger->critical('');
+        $logger->error('');
+        $logger->notice('');
+        $logger->info('');
+        $logger->debug('');
+        $logger->warning('');
     }
 
     public function testLoggerLogOnlyHigherLevelThanError()
@@ -261,44 +261,44 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::once())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::once())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::once())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::never())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::never())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::never())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::never())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("");
-        $logger->alert("");
-        $logger->critical("");
-        $logger->error("");
-        $logger->notice("");
-        $logger->info("");
-        $logger->debug("");
-        $logger->warning("");
+        $logger->emergency('');
+        $logger->alert('');
+        $logger->critical('');
+        $logger->error('');
+        $logger->notice('');
+        $logger->info('');
+        $logger->debug('');
+        $logger->warning('');
     }
 
     public function testLoggerLogOnlyHigherLevelThanCritical()
@@ -309,44 +309,44 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::once())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::once())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::never())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::never())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::never())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::never())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::never())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("");
-        $logger->alert("");
-        $logger->critical("");
-        $logger->error("");
-        $logger->notice("");
-        $logger->info("");
-        $logger->debug("");
-        $logger->warning("");
+        $logger->emergency('');
+        $logger->alert('');
+        $logger->critical('');
+        $logger->error('');
+        $logger->notice('');
+        $logger->info('');
+        $logger->debug('');
+        $logger->warning('');
     }
 
     public function testLoggerLogOnlyHigherLevelThanAlert()
@@ -357,44 +357,44 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::once())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::never())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::never())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::never())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::never())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::never())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::never())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("");
-        $logger->alert("");
-        $logger->critical("");
-        $logger->error("");
-        $logger->notice("");
-        $logger->info("");
-        $logger->debug("");
-        $logger->warning("");
+        $logger->emergency('');
+        $logger->alert('');
+        $logger->critical('');
+        $logger->error('');
+        $logger->notice('');
+        $logger->info('');
+        $logger->debug('');
+        $logger->warning('');
     }
 
     public function testLoggerNoLog()
@@ -405,88 +405,88 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::never())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::never())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::never())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::never())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::never())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::never())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::never())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("");
-        $logger->alert("");
-        $logger->critical("");
-        $logger->error("");
-        $logger->notice("");
-        $logger->info("");
-        $logger->debug("");
-        $logger->warning("");
+        $logger->emergency('');
+        $logger->alert('');
+        $logger->critical('');
+        $logger->error('');
+        $logger->notice('');
+        $logger->info('');
+        $logger->debug('');
+        $logger->warning('');
     }
 
     public function testClientNoLog()
     {
         $mockLogger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 
-        $client = new ConfigCatClient("not-existing", [
+        $client = new ConfigCatClient('not-existing', [
            ClientOptions::LOGGER => $mockLogger,
-           ClientOptions::LOG_LEVEL => LogLevel::NO_LOG
+           ClientOptions::LOG_LEVEL => LogLevel::NO_LOG,
         ]);
 
         $mockLogger
             ->expects(self::never())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::never())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::never())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::never())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::never())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::never())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::never())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $client->getValue("fake", false);
+        $client->getValue('fake', false);
     }
 
     public function testLoggerBypassesLogWhenExceptionIsIgnored()
@@ -497,43 +497,43 @@ class LoggerTest extends TestCase
 
         $mockLogger
             ->expects(self::never())
-            ->method("emergency");
+            ->method('emergency');
 
         $mockLogger
             ->expects(self::never())
-            ->method("alert");
+            ->method('alert');
 
         $mockLogger
             ->expects(self::never())
-            ->method("critical");
+            ->method('critical');
 
         $mockLogger
             ->expects(self::never())
-            ->method("error");
+            ->method('error');
 
         $mockLogger
             ->expects(self::never())
-            ->method("warning");
+            ->method('warning');
 
         $mockLogger
             ->expects(self::never())
-            ->method("notice");
+            ->method('notice');
 
         $mockLogger
             ->expects(self::never())
-            ->method("info");
+            ->method('info');
 
         $mockLogger
             ->expects(self::never())
-            ->method("debug");
+            ->method('debug');
 
-        $logger->emergency("", ['exception' => new InvalidArgumentException()]);
-        $logger->alert("", ['exception' => new InvalidArgumentException()]);
-        $logger->critical("", ['exception' => new InvalidArgumentException()]);
-        $logger->error("", ['exception' => new InvalidArgumentException()]);
-        $logger->notice("", ['exception' => new InvalidArgumentException()]);
-        $logger->info("", ['exception' => new InvalidArgumentException()]);
-        $logger->debug("", ['exception' => new InvalidArgumentException()]);
-        $logger->warning("", ['exception' => new InvalidArgumentException()]);
+        $logger->emergency('', ['exception' => new InvalidArgumentException()]);
+        $logger->alert('', ['exception' => new InvalidArgumentException()]);
+        $logger->critical('', ['exception' => new InvalidArgumentException()]);
+        $logger->error('', ['exception' => new InvalidArgumentException()]);
+        $logger->notice('', ['exception' => new InvalidArgumentException()]);
+        $logger->info('', ['exception' => new InvalidArgumentException()]);
+        $logger->debug('', ['exception' => new InvalidArgumentException()]);
+        $logger->warning('', ['exception' => new InvalidArgumentException()]);
     }
 }

--- a/tests/RolloutIntegrationsTest.php
+++ b/tests/RolloutIntegrationsTest.php
@@ -10,23 +10,19 @@ use PHPUnit\Framework\TestCase;
 
 class RolloutIntegrationsTest extends TestCase
 {
-    const valueKind = 0;
-    const variationKind = 1;
+    final public const valueKind = 0;
+    final public const variationKind = 1;
 
     /**
-     * @param $file
-     * @param $sdkKey
-     * @param $kind
-     *
      * @dataProvider rolloutTestData
      */
     public function testRolloutIntegration($file, $sdkKey, $kind)
     {
-        $rows = self::readCsv("tests/" . $file);
-        $settingKeys = array_slice($rows[0], 4);
+        $rows = self::readCsv('tests/'.$file);
+        $settingKeys = \array_slice($rows[0], 4);
         $customKey = $rows[0][3];
         $client = new ConfigCatClient($sdkKey, [
-            ClientOptions::LOG_LEVEL => LogLevel::WARNING
+            ClientOptions::LOG_LEVEL => LogLevel::WARNING,
         ]);
 
         $errors = [];
@@ -34,32 +30,32 @@ class RolloutIntegrationsTest extends TestCase
         $keys = $client->getAllKeys();
         $diff = array_diff($settingKeys, $keys);
         if (!empty($diff)) {
-            $errors[] = sprintf("Not all keys are found, Expected: %s, Result: %s, Diff: %s",
+            $errors[] = sprintf('Not all keys are found, Expected: %s, Result: %s, Diff: %s',
                 print_r($settingKeys, true),
                 print_r($keys, true),
                 print_r($diff, true));
         }
 
-        foreach (range(1, count($rows) - 1) as $i) {
+        foreach (range(1, \count($rows) - 1) as $i) {
             $testObjects = $rows[$i];
 
             $user = null;
-            if ($testObjects[0] !== "##null##") {
+            if ('##null##' !== $testObjects[0]) {
                 $identifier = $testObjects[0];
 
-                $email = "";
-                $country = "";
+                $email = '';
+                $country = '';
 
-                if (!empty($testObjects[1]) && $testObjects[1] !== "##null##") {
+                if (!empty($testObjects[1]) && '##null##' !== $testObjects[1]) {
                     $email = $testObjects[1];
                 }
 
-                if (!empty($testObjects[2]) && $testObjects[2] !== "##null##") {
+                if (!empty($testObjects[2]) && '##null##' !== $testObjects[2]) {
                     $country = $testObjects[2];
                 }
 
                 $custom = [];
-                if (!empty($testObjects[3]) && $testObjects[3] !== "##null##") {
+                if (!empty($testObjects[3]) && '##null##' !== $testObjects[3]) {
                     $custom[$customKey] = $testObjects[3];
                 } elseif (is_numeric($testObjects[3])) {
                     $custom[$customKey] = $testObjects[3];
@@ -71,36 +67,36 @@ class RolloutIntegrationsTest extends TestCase
             $count = 0;
             foreach ($settingKeys as $key) {
                 $expected = $testObjects[$count + 4];
-                $actual = $kind == self::valueKind
+                $actual = self::valueKind == $kind
                     ? $client->getValue($key, null, $user)
                     : $client->getVariationId($key, null, $user);
 
-                if (is_bool($actual)) {
-                    $actual = $actual ? "True" : "False";
+                if (\is_bool($actual)) {
+                    $actual = $actual ? 'True' : 'False';
                 }
 
-                if (is_int($actual)) {
-                    $expected = intval($expected);
+                if (\is_int($actual)) {
+                    $expected = (int) $expected;
                 }
 
-                if (is_double($actual)) {
-                    $expected = floatval($expected);
+                if (\is_float($actual)) {
+                    $expected = (float) $expected;
                 }
 
                 if ($expected !== $actual) {
-                    $errors[] = sprintf("Identifier: %s, SettingKey: %s, UV: %s, Expected: %s, Result: %s", $testObjects[0], $key, $testObjects[3], $expected, $actual);
+                    $errors[] = sprintf('Identifier: %s, SettingKey: %s, UV: %s, Expected: %s, Result: %s', $testObjects[0], $key, $testObjects[3], $expected, $actual);
                 }
-                $count++;
+                ++$count;
             }
         }
 
-        $this->assertEquals(0, count($errors));
+        $this->assertEquals(0, \count($errors));
     }
 
     private static function readCsv($file): array
     {
         $rows = [];
-        if (($handle = fopen($file, "r")) !== false) {
+        if (($handle = fopen($file, 'r')) !== false) {
             while (($data = fgetcsv($handle, 1200, ';')) !== false) {
                 $rows[] = $data;
             }
@@ -113,12 +109,12 @@ class RolloutIntegrationsTest extends TestCase
     public function rolloutTestData(): array
     {
         return [
-            ["testmatrix.csv", "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A", self::valueKind],
-            ["testmatrix_semantic.csv", "PKDVCLf-Hq-h-kCzMp-L7Q/BAr3KgLTP0ObzKnBTo5nhA", self::valueKind],
-            ["testmatrix_number.csv", "PKDVCLf-Hq-h-kCzMp-L7Q/uGyK3q9_ckmdxRyI7vjwCw", self::valueKind],
-            ["testmatrix_semantic_2.csv", "PKDVCLf-Hq-h-kCzMp-L7Q/q6jMCFIp-EmuAfnmZhPY7w", self::valueKind],
-            ["testmatrix_sensitive.csv", "PKDVCLf-Hq-h-kCzMp-L7Q/qX3TP2dTj06ZpCCT1h_SPA", self::valueKind],
-            ["testmatrix_variationId.csv", "PKDVCLf-Hq-h-kCzMp-L7Q/nQ5qkhRAUEa6beEyyrVLBA", self::variationKind],
+            ['testmatrix.csv', 'PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A', self::valueKind],
+            ['testmatrix_semantic.csv', 'PKDVCLf-Hq-h-kCzMp-L7Q/BAr3KgLTP0ObzKnBTo5nhA', self::valueKind],
+            ['testmatrix_number.csv', 'PKDVCLf-Hq-h-kCzMp-L7Q/uGyK3q9_ckmdxRyI7vjwCw', self::valueKind],
+            ['testmatrix_semantic_2.csv', 'PKDVCLf-Hq-h-kCzMp-L7Q/q6jMCFIp-EmuAfnmZhPY7w', self::valueKind],
+            ['testmatrix_sensitive.csv', 'PKDVCLf-Hq-h-kCzMp-L7Q/qX3TP2dTj06ZpCCT1h_SPA', self::valueKind],
+            ['testmatrix_variationId.csv', 'PKDVCLf-Hq-h-kCzMp-L7Q/nQ5qkhRAUEa6beEyyrVLBA', self::variationKind],
         ];
     }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -3,20 +3,19 @@
 namespace ConfigCat\Tests;
 
 use ConfigCat\User;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase
 {
     public function testConstructEmptyIdentifier()
     {
-        $user = new User("");
-        $this->assertEquals("", $user->getIdentifier());
+        $user = new User('');
+        $this->assertEquals('', $user->getIdentifier());
     }
 
     public function testGetAttributeEmptyKey()
     {
-        $user = new User("id");
-        $this->assertEquals("", $user->getAttribute(""));
+        $user = new User('id');
+        $this->assertEquals('', $user->getAttribute(''));
     }
 }

--- a/tests/Utils.php
+++ b/tests/Utils.php
@@ -16,26 +16,27 @@ class Utils
         $handler = new ErrorLogHandler();
         $formatter = new LineFormatter(null, null, true, true);
         $handler->setFormatter($formatter);
-        return new InternalLogger(new Logger("ConfigCat", [$handler]), LogLevel::WARNING, [], new Hooks());
+
+        return new InternalLogger(new Logger('ConfigCat', [$handler]), LogLevel::WARNING, [], new Hooks());
     }
 
     public static function formatConfigWithRules(): string
     {
-        return "{ \"f\": { \"key\": { \"v\": \"def\", \"i\": \"defVar\", \"p\": [], \"r\": [
+        return '{ "f": { "key": { "v": "def", "i": "defVar", "p": [], "r": [
             {
-                \"v\": \"fake1\",
-                \"i\": \"id1\",
-                \"t\": 2,
-                \"a\": \"Identifier\",
-                \"c\": \"@test1.com\"
+                "v": "fake1",
+                "i": "id1",
+                "t": 2,
+                "a": "Identifier",
+                "c": "@test1.com"
             },
             {
-                \"v\": \"fake2\",
-                \"i\": \"id2\",
-                \"t\": 2,
-                \"a\": \"Identifier\",
-                \"c\": \"@test2.com\"
+                "v": "fake2",
+                "i": "id2",
+                "t": 2,
+                "a": "Identifier",
+                "c": "@test2.com"
             }
-        ] }}}";
+        ] }}}';
     }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

As security support for 7.4 ends on 28 Nov 2022 and active support for 8.0 ends on 26 Nov 2022 I suggest to bump all versions prior to PHP 8.1.

Therefore I
- updated dependencies
- added type declarations
- used new initializers and readonly properties
- did some code style cleanup
- updated code samples accordingly

No changes in functionality or behavior were made.

### Requirement checklist (only if applicable)

- [X] I have covered the applied changes with automated tests.
- [X] I have executed the full automated test set against my changes.
- [X] I have validated my changes against all supported platform versions.
- [X] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
