### PR TITLE
Add more files to gitattributes to reduce package size even more

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,11 @@
-/tests export-ignore
+/.github export-ignore
+/media export-ignore
 /samples export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.sonarcloud.properties export-ignore
+/CONTRIBUTING.md export-ignore
+/DEPLOY.md export-ignore
+/phpcs.xml export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
### Describe the purpose of your pull request

Added more files to .gitattributes list as export-ignore. They are not used in vendor package.
This way the packages size is reduced even more resulting to less data needed to download
