### PR TITLE
Make getValueDetails return type mixed, since it has to be compatible with default value type

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -26,7 +26,7 @@ interface ClientInterface
      * @param ?User $user The user object to identify the caller.
      * @return mixed The configuration value identified by the given key.
      */
-    public function getValueDetails(string $key, mixed $defaultValue, ?User $user = null): EvaluationDetails;
+    public function getValueDetails(string $key, mixed $defaultValue, ?User $user = null): mixed;
 
     /**
      * Gets the Variation ID (analytics) of a feature flag or setting by the given key.

--- a/src/ConfigCatClient.php
+++ b/src/ConfigCatClient.php
@@ -177,7 +177,7 @@ final class ConfigCatClient implements ClientInterface
      * @param ?User $user The user object to identify the caller.
      * @return mixed The configuration value identified by the given key.
      */
-    public function getValueDetails(string $key, mixed $defaultValue, ?User $user = null): EvaluationDetails
+    public function getValueDetails(string $key, mixed $defaultValue, ?User $user = null): mixed
     {
         try {
             $settingsResult = $this->getSettingsResult();

--- a/tests/ConfigCatClientTest.php
+++ b/tests/ConfigCatClientTest.php
@@ -410,6 +410,15 @@ class ConfigCatClientTest extends TestCase
         $this->assertFalse($details->isDefaultValue());
     }
 
+    public function testEvalMissingDetails()
+    {
+        $client = new ConfigCatClient("testEvalDetails", [ClientOptions::CUSTOM_HANDLER => new MockHandler([
+            new Response(200, [], Utils::formatConfigWithRules())
+        ])]);
+
+        $this->assertNull($client->getValueDetails("unknown-key", null));
+    }
+
     public function testEvalDetailsHook()
     {
         $client = new ConfigCatClient("testEvalDetailsHook", [ClientOptions::CUSTOM_HANDLER => new MockHandler([


### PR DESCRIPTION
### Describe the purpose of your pull request

`getValueDetails` has a fixed return type of `EvaluationDetails`, but in case of missing feature key `$defaultValue` is used as a return, which might be anything (mixed type). Therefore `getValueDetails` should also has a return type of mixed.

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
