### PR TITLE
Drop guzzle v6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "guzzlehttp/guzzle": "^6.3|^7.0",
+    "guzzlehttp/guzzle": "^7.0",
     "psr/log": "^2.0|^3.0",
     "ext-json": "*",
     "z4kn4fein/php-semver": "^2.0",


### PR DESCRIPTION
### Describe the purpose of your pull request

Guzzle has become compatible with PSR-18 (ClientInterface) only starting with v7. 
Using guzzle v6 does not work as `ConfigCat\Http\FetchClientInterface::getClient` return type is not compatible